### PR TITLE
Add failing test for inhaler comparison

### DIFF
--- a/index.html
+++ b/index.html
@@ -2999,7 +2999,7 @@ if (!order.form) {
     { standard: "transdermal", variations: ["transdermal"] }, { standard: "ophthalmic", variations: ["ophthalmic", "in eye", "eye drop"] },
     { standard: "otic", variations: ["otic", "in ear", "ear drop"] }, { standard: "nasal", variations: ["nasal", "intranasal", "in nose", "nasal spray"] },
     { standard: "vaginal", variations: ["vaginal", "vaginally"] }, { standard: "urethral", variations: ["urethral"] },
-    { standard: "intrauterine", variations: ["intrauterine"] }, { standard: "inhalation", variations: ["inhalation", "inhaled", "inh", "mdi", "dpi", "nebulized", "neb"] },
+    { standard: "intrauterine", variations: ["intrauterine"] }, { standard: "inhalation", variations: ["inhalation", "inhalations", "inhaled", "inh", "inhale", "mdi", "dpi", "nebulized", "neb", "handihaler", "respimat"] },
     { standard: "intraperitoneal", variations: ["intraperitoneal"] }, { standard: "intraarticular", variations: ["intraarticular", "intra-articular"] },
     { standard: "intrapleural", variations: ["intrapleural"] }, { standard: "intravesical", variations: ["intravesical"] },
     { standard: "implantable", variations: ["implantable"] }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "medrec-2.0",
+  "version": "1.0.0",
+  "description": "Medication reconciliation app.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node tests/runTests.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadAppContext() {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const script = html.split('<script>')[2].split('</script>')[0];
+  const context = {
+    console: { log: () => {}, warn: () => {}, error: () => {} },
+    window: {},
+    document: { querySelectorAll: () => [], getElementById: () => ({}), addEventListener: () => {} },
+    firebase: { initializeApp: () => ({}), functions: () => ({ httpsCallable: () => () => ({}) }) }
+  };
+  vm.createContext(context);
+  vm.runInContext(script, context);
+  return context;
+}
+
+describe('Medication comparison', () => {
+  test('dose and form changes detected for Spiriva Respimat vs tiotropium', () => {
+    const ctx = loadAppContext();
+    const before = 'Tiotropium 18 mcg capsule – inhale contents of one capsule via HandiHaler once daily';
+    const after = 'Spiriva Respimat 2.5 mcg/actuation – 2 inhalations once daily';
+    const p1 = ctx.parseOrder(before);
+    const p2 = ctx.parseOrder(after);
+    const result = ctx.getChangeReason(p1, p2);
+    expect(result).toBe('Dose changed, Form changed');
+  });
+});

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -1,0 +1,22 @@
+// Minimal test harness to run Jest-style tests without dependencies
+global.describe = (name, fn) => { console.log(name); fn(); };
+global.test = (name, fn) => {
+  try {
+    fn();
+    console.log('  \x1b[32m✓\x1b[0m', name);
+  } catch (err) {
+    console.log('  \x1b[31m✗\x1b[0m', name);
+    console.error(err.message);
+    process.exitCode = 1;
+  }
+};
+
+global.expect = actual => ({
+  toBe: expected => {
+    if (actual !== expected) {
+      throw new Error(`Expected ${expected} but received ${actual}`);
+    }
+  }
+});
+
+require('./medDiff.test');


### PR DESCRIPTION
## Summary
- add failing test harness with simple runner
- recognize inhaler-related terms as the inhalation route
- run Jest-style tests via Node

## Testing
- `npm test`