### PR TITLE
Handle before-meals frequency

### DIFF
--- a/index.html
+++ b/index.html
@@ -2166,9 +2166,12 @@ function getChangeReason(orig, updated) {
 
   const norm = s => (s || '').toLowerCase().trim().replace(/\s+/g, ' ');
   const canon = f => {
-    f = norm(f);
-    return (f === '' || f === 'daily' || f === 'q24h') ? 'daily' : f;
-  };
+    f = norm(f);
+    if (f === '' || f === 'daily' || f === 'q24h') return 'daily';
+    if (['tid', 'tidac', 'three times daily'].includes(f)) return 'tid';
+    if (/(?:before|with) meals/.test(f) || /before breakfast lunch dinner/.test(f)) return 'tid';
+    return f;
+  };
 
   // --- Initial properties from parsed objects ---
   const origDrugNameRaw = orig.drug; // Keep as parsed, before normalizeMedicationName
@@ -2575,6 +2578,20 @@ if (order.timeOfDay && !order.frequency) {
 /* ——— NEW: capture “before / after breakfast|lunch|dinner”
           with an optional numeric offset ——— */
 if (!order.timeOfDay) {
+  const mealFreqMatch = orderStr.match(/\b(?:before|with)\s+meals\b/i);
+  if (mealFreqMatch) {
+    if (!order.frequency) order.frequency = 'tid';
+    orderStr = orderStr.replace(mealFreqMatch[0], '').trim();
+  }
+}
+if (!order.timeOfDay) {
+  const explicitMeals = orderStr.match(/\bbefore\s+breakfast\s+lunch\s+dinner\b/i);
+  if (explicitMeals) {
+    if (!order.frequency) order.frequency = 'tid';
+    orderStr = orderStr.replace(explicitMeals[0], '').trim();
+  }
+}
+if (!order.timeOfDay) {
   const mealTiming =
     orderStr.match(/\b(?:\d+\s*(?:min(?:ute)?s?|hr|hrs?|hours?)\s*)?(before|after)\s+(breakfast|lunch|dinner)\b/i);
   if (mealTiming) {
@@ -2608,6 +2625,9 @@ orderStr = orderStr
     const prefix = adminMatch[0].toLowerCase().startsWith('with') ? 'with ' : 'without ';
     const noun = (adminMatch[1] || adminMatch[2] || '').toLowerCase();
     order.administration = prefix + noun;
+    if (!order.frequency && /(?:before|with)\s+meals?/i.test(adminMatch[0])) {
+      order.frequency = 'tid';
+    }
     orderStr = orderStr.replace(adminMatch[0], '').trim();
     // console.log(`DEBUG parseOrder Step 2 (Admin): order.administration="${order.administration}", orderStr="${orderStr}"`);
   }
@@ -3053,7 +3073,7 @@ if (!order.frequency) { // <<<< ADD THIS OPENING 'if' and its brace
           const freqMapping = { /* ... your existing map ... */
               "once daily": "daily", "once a day": "daily", "1 times daily": "daily", "daily": "daily", "od": "daily", "qd": "daily",
               "twice daily": "twice daily", "2 times daily": "twice daily", "bid": "twice daily", "twice a day": "twice daily",
-              "three times daily": "three times daily", "3 times daily": "three times daily", "tid": "three times daily",
+              "three times daily": "three times daily", "3 times daily": "three times daily", "tid": "three times daily", "tidac": "three times daily", "before meals": "three times daily", "with meals": "three times daily", "before breakfast lunch dinner": "three times daily",
               "four times daily": "four times daily", "4 times daily": "four times daily", "qid": "four times daily",
               "every other day": "every other day", "qod": "every other day",
               "stat": "immediately", "now": "immediately",

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -19,4 +19,33 @@ global.expect = actual => ({
   }
 });
 
+// Alias used by some tests
+global.addTest = (name, fn) => test(name, fn);
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function diff(before, after) {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const script = html.split('<script>')[2].split('</script>')[0];
+  const context = {
+    console: { log: () => {}, warn: () => {}, error: () => {} },
+    window: {},
+    document: { querySelectorAll: () => [], getElementById: () => ({}), addEventListener: () => {} },
+    firebase: { initializeApp: () => ({}), functions: () => ({ httpsCallable: () => () => ({}) }) }
+  };
+  vm.createContext(context);
+  vm.runInContext(script, context);
+  const p1 = context.parseOrder(before);
+  const p2 = context.parseOrder(after);
+  return context.getChangeReason(p1, p2);
+}
+
 require('./medDiff.test');
+
+addTest('Insulin before-meals equals TIDAC dose change only', () => {
+  const before = 'Insulin Aspart (Novolog) FlexPen - Inject 10 units subcutaneously TIDAC';
+  const after = 'Novolog FlexPen - Inject 12 units SC before meals (breakfast lunch dinner)';
+  expect(diff(before, after)).toBe('Dose changed');
+});


### PR DESCRIPTION
## Summary
- support `before meals`/`with meals` phrases in medication parsing
- treat `tid`, `tidac`, and meal phrases as equivalent frequencies
- adjust diff test for before-meal insulin

## Testing
- `npm test`