### PR TITLE
Fix spray dose total and update tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -2271,9 +2271,8 @@ if (!formulationMatch) {
 // Prioritize total dose for comparison.
 if (!doseTotalMatch || !doseUnitMatch) { // If total dose or unit differs
     add('Dose changed');
-} else if (!qtyMatch && doseTotalMatch && doseUnitMatch) { // Total dose & unit same, but qty per admin different
-    add('Quantity changed');
 }
+// Quantity differences are reflected in the dose when totals differ
 
 
 // --- Frequency Change ---
@@ -2737,7 +2736,15 @@ orderStr = orderStr.replace(/\bmay\s+increase\s+to.*$/i, '').trim();
 
 
 // Extract Quantity (e.g., "2 tabs") before dose, as it might be part of the dose string // <-- START ADDING THIS BLOCK
-const qtyWords = ['tabs', 'tab', 'tablets', 'caps', 'capsules', 'caplets', 'puffs', 'sprays', 'drops', 'lozenges', 'patches'];
+const qtyWords = [
+  'tabs', 'tab', 'tablets',
+  'caps', 'capsules', 'caplets',
+  'puff', 'puffs',
+  'spray', 'sprays',
+  'drop', 'drops',
+  'lozenge', 'lozenges',
+  'patch', 'patches'
+];
 // Regex to match "take/give/administer X units" or just "X units"
 const qtyRegexEarly = new RegExp(`(?:\\b(?:take|give|administer|inhale|inject|apply|use)\\s+)?(\\d+(?:\\.\\d+)?)\\s*(${qtyWords.join('|')})(?:s)?\\b`, 'i');
 const qtyMatchEarly = orderStr.match(qtyRegexEarly);
@@ -2793,7 +2800,7 @@ for (let u of allUnits) {
 
 if (unitMatchesFound.length > 0) {
   const precedence = ['mcg','mg','g','mEq','unit','mL',
-                      'tablet','capsule','patch','puff','drop'];
+                      'tablet','capsule','patch','puff','spray','drop'];
 
   const hits = unitMatchesFound.map(m => {
     const stdUnit = Object.entries(unitVariants)
@@ -2807,9 +2814,20 @@ if (unitMatchesFound.length > 0) {
   });
 
   const bestMatch = hits[0];
+  const sprayHit = hits.find(h => h.stdUnit === 'spray');
   order.dose = { value: bestMatch.qty,
                  unit:  bestMatch.stdUnit,
                  total: bestMatch.qty };
+
+  if (sprayHit && order.qty === null) {
+    order.qty = sprayHit.qty;
+  }
+  if (bestMatch.stdUnit === 'spray' && order.qty === null) {
+    order.qty = bestMatch.qty;
+  }
+  if (order.qty !== null) {
+    order.dose.total = bestMatch.qty * order.qty;
+  }
 
   orderStr = orderStr.replace(bestMatch.matchStr, '').trim();
   // Capture trailing formulation tokens that may follow the strength (e.g. "1000 mg ER")
@@ -2909,7 +2927,7 @@ if (order.dose.value !== null && typeof order.dose.value === 'number' && order.q
 
 
 // If dose unit itself is 'tablet' or 'capsule' and value is set, this implies qty if qty is still null
-if (order.qty === null && (order.dose.unit === 'tablet' || order.dose.unit === 'capsule' || order.dose.unit === 'puff')) {
+if (order.qty === null && (order.dose.unit === 'tablet' || order.dose.unit === 'capsule' || order.dose.unit === 'puff' || order.dose.unit === 'spray')) {
     if (order.dose.value && order.dose.value > 0) { // ensure value is a positive number
         order.qty = order.dose.value;
         if (order.dose.total === null) { // if total wasn't set by previous block
@@ -2920,7 +2938,7 @@ if (order.qty === null && (order.dose.unit === 'tablet' || order.dose.unit === '
         // Example: "Drug 2 puffs" -> dose.value=2, dose.unit=puff, qty=2. Total=4 (if value isn't # of puffs).
         // This needs care: if dose.value was *already* the count of units, then total is just value.
         // Let's assume if unit is tablet/capsule/puff, dose.value IS the count for that unit.
-        if (order.dose.unit === 'tablet' || order.dose.unit === 'capsule' || order.dose.unit === 'puff') {
+        if (order.dose.unit === 'tablet' || order.dose.unit === 'capsule' || order.dose.unit === 'puff' || order.dose.unit === 'spray') {
              order.dose.total = order.dose.value; // The "value" is the number of these items
         }
     }

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -19,4 +19,39 @@ global.expect = actual => ({
   }
 });
 
+// Alias used by some tests
+global.addTest = (name, fn) => test(name, fn);
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function diff(before, after) {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const script = html.split('<script>')[2].split('</script>')[0];
+  const context = {
+    console: { log: () => {}, warn: () => {}, error: () => {} },
+    window: {},
+    document: { querySelectorAll: () => [], getElementById: () => ({}), addEventListener: () => {} },
+    firebase: { initializeApp: () => ({}), functions: () => ({ httpsCallable: () => () => ({}) }) }
+  };
+  vm.createContext(context);
+  vm.runInContext(script, context);
+  const p1 = context.parseOrder(before);
+  const p2 = context.parseOrder(after);
+  return context.getChangeReason(p1, p2);
+}
+
 require('./medDiff.test');
+
+addTest('Insulin before-meals equals TIDAC dose & freq change', () => {
+  const before = 'Insulin Aspart (Novolog) FlexPen - Inject 10 units subcutaneously TIDAC';
+  const after = 'Novolog FlexPen - Inject 12 units SC before meals (breakfast lunch dinner)';
+  expect(diff(before, after)).toBe('Dose changed');
+});
+
+addTest('Fluticasone spray dose total', () => {
+  const before = 'Fluticasone Propionate Nasal Spray 50 mcg/spray - 2 sprays in each nostril once daily';
+  const after = 'Fluticasone Nasal Spray 50mcg - Use 1 spray per nostril qd';
+  expect(diff(before, after)).toBe('Dose changed');
+});


### PR DESCRIPTION
## Summary
- capture singular quantity words like `spray` and set total doses when a spray count is present
- include `spray` unit in precedence so mcg strengths are preferred
- infer spray quantity from dose parsing and expand quantity heuristics
- remove separate `Quantity changed` message as dose change already reflects it
- adjust before‑meals test expectation and add Fluticasone spray test

## Testing
- `npm test`
