### PR TITLE
Fix Metformin timing test

### DIFF
--- a/index.html
+++ b/index.html
@@ -2596,9 +2596,9 @@ orderStr = orderStr
   // 2. Extract Administration (with/without food/water)
   const adminMatch = orderStr.match(
   new RegExp(
-    String.raw`\b(?:with|w\/)\s*(?:meals?|food|water|juice|liquid)\b|` +
-    String.raw`\b(?:without|w\/o)\s*(?:meals?|food|water|juice|liquid)\b|` +
-    String.raw`\b(?:before|after)\s*(?:meals?|food)\b`,
+    String.raw`\b(?:with|w\/)\s*(?:meals?|food|water|juice|liquid|supper|breakfast|lunch|dinner)\b|` +
+    String.raw`\b(?:without|w\/o)\s*(?:meals?|food|water|juice|liquid|supper|breakfast|lunch|dinner)\b|` +
+    String.raw`\b(?:before|after)\s*(?:meals?|food|supper|breakfast|lunch|dinner)\b`,
     'i'
   )
 );
@@ -2617,8 +2617,7 @@ const formulationKeywords = [
     'modified release', 'delayed release', 'extended release', 'controlled release', // Multi-word first
     'xr', 'er', 'sr', 'la', 'xl', 'cr', 'dr',
     'succinate', 'tartrate', 'maleate', 'fumarate', 'besylate', 'camsylate', 'mesylate',
-    'acetate', 'phosphate', 'carbonate', 'gluconate',
-    'hcl', 'hydrochloride'
+    'acetate', 'phosphate', 'carbonate', 'gluconate'
 ].sort((a, b) => b.length - a.length); // Sort by length, longest first is crucial
 
 let processedOrderStrForFormulation = orderStr; // Work on a copy

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -19,4 +19,39 @@ global.expect = actual => ({
   }
 });
 
+// Alias used by some tests
+global.addTest = (name, fn) => test(name, fn);
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function diff(before, after) {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const script = html.split('<script>')[2].split('</script>')[0];
+  const context = {
+    console: { log: () => {}, warn: () => {}, error: () => {} },
+    window: {},
+    document: { querySelectorAll: () => [], getElementById: () => ({}), addEventListener: () => {} },
+    firebase: { initializeApp: () => ({}), functions: () => ({ httpsCallable: () => () => ({}) }) }
+  };
+  vm.createContext(context);
+  vm.runInContext(script, context);
+  const p1 = context.parseOrder(before);
+  const p2 = context.parseOrder(after);
+  return context.getChangeReason(p1, p2);
+}
+
 require('./medDiff.test');
+
+addTest('Insulin before-meals equals TIDAC dose & freq change', () => {
+  const before = 'Insulin Aspart (Novolog) FlexPen - Inject 10 units subcutaneously TIDAC';
+  const after = 'Novolog FlexPen - Inject 12 units SC before meals (breakfast lunch dinner)';
+  expect(diff(before, after)).toBe('Dose changed');
+});
+
+addTest('Metformin evening vs nightly time change', () => {
+  const before = 'Metformin hydrochloride 1000mg ER - take one tablet by mouth every evening with supper';
+  const after = 'Metformin ER 1000mg - take 1 tab PO nightly with food';
+  expect(diff(before, after)).toBe('Time of day changed');
+});


### PR DESCRIPTION
## Summary
- include 'supper' and meal terms in admin parsing
- do not treat salts as formulations
- adjust before-meals insulin test expectation
- add a Metformin evening vs nightly test

## Testing
- `npm test`
