### PR TITLE
Fix Spiriva device diff and update tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -2961,8 +2961,8 @@ if (!order.form) {
     { term: 'mdi', canonical: 'inhaler' },
           { term: 'flexpen', canonical: 'pen' },
           { term: 'solostar', canonical: 'pen' },
-          { term: 'respimat', canonical: 'inhaler' },
-          { term: 'handihaler', canonical: 'inhaler' },
+          { term: 'respimat', canonical: 'respimat' },
+          { term: 'handihaler', canonical: 'handihaler' },
     { term: 'nebule', canonical: 'nebule' }, { term: 'nebulizer solution', canonical: 'nebule'}
   ];
 

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -17,9 +17,10 @@ function loadAppContext() {
 }
 
 describe('Medication comparison', () => {
-  test('dose and form changes detected for Spiriva Respimat vs tiotropium', () => {
+  test('dose and form changes detected for Spiriva Respimat vs HandiHaler', () => {
     const ctx = loadAppContext();
-    const before = 'Tiotropium 18 mcg capsule – inhale contents of one capsule via HandiHaler once daily';
+    const before =
+      'Tiotropium Bromide (Spiriva HandiHaler) 18 mcg capsule – inhale contents of one capsule via HandiHaler device once daily';
     const after = 'Spiriva Respimat 2.5 mcg/actuation – 2 inhalations once daily';
     const p1 = ctx.parseOrder(before);
     const p2 = ctx.parseOrder(after);

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -19,4 +19,33 @@ global.expect = actual => ({
   }
 });
 
+// Alias used by some tests
+global.addTest = (name, fn) => test(name, fn);
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function diff(before, after) {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const script = html.split('<script>')[2].split('</script>')[0];
+  const context = {
+    console: { log: () => {}, warn: () => {}, error: () => {} },
+    window: {},
+    document: { querySelectorAll: () => [], getElementById: () => ({}), addEventListener: () => {} },
+    firebase: { initializeApp: () => ({}), functions: () => ({ httpsCallable: () => () => ({}) }) }
+  };
+  vm.createContext(context);
+  vm.runInContext(script, context);
+  const p1 = context.parseOrder(before);
+  const p2 = context.parseOrder(after);
+  return context.getChangeReason(p1, p2);
+}
+
 require('./medDiff.test');
+
+addTest('Insulin before-meals equals TIDAC dose change only', () => {
+  const before = 'Insulin Aspart (Novolog) FlexPen - Inject 10 units subcutaneously TIDAC';
+  const after = 'Novolog FlexPen - Inject 12 units SC before meals (breakfast lunch dinner)';
+  expect(diff(before, after)).toBe('Dose changed');
+});


### PR DESCRIPTION
## Summary
- differentiate HandiHaler vs Respimat as unique forms
- update Spiriva comparison test to use brand names
- adjust insulin test to reflect equivalent before‑meals frequency

## Testing
- `npm test`