### PR TITLE
Handle Warfarin sodium formulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2638,7 +2638,7 @@ const formulationKeywords = [
     'modified release', 'delayed release', 'extended release', 'controlled release', // Multi-word first
     'xr', 'er', 'sr', 'la', 'xl', 'cr', 'dr',
     'succinate', 'tartrate', 'maleate', 'fumarate', 'besylate', 'camsylate', 'mesylate',
-    'acetate', 'phosphate', 'carbonate', 'gluconate'
+    'acetate', 'phosphate', 'carbonate', 'gluconate', 'sodium'
 ].sort((a, b) => b.length - a.length); // Sort by length, longest first is crucial
 
 let processedOrderStrForFormulation = orderStr; // Work on a copy

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -68,3 +68,9 @@ addTest('Fluticasone spray dose total', () => {
   expect(diff(before, after)).toBe('Dose changed');
 });
 
+addTest('Warfarin sodium formulation difference', () => {
+  const before = 'Warfarin sodium 5 mg tablet - take one daily';
+  const after = 'Warfarin 5 mg tablet - take one daily';
+  expect(diff(before, after)).toBe('Formulation changed');
+});
+


### PR DESCRIPTION
## Summary
- parseOrder: detect 'sodium' as a formulation keyword
- add regression test for Warfarin sodium formulation change

## Testing
- `npm test`