### PR TITLE
Add sublingually route

### DIFF
--- a/index.html
+++ b/index.html
@@ -3040,7 +3040,7 @@ if (!order.form) {
 
   // 7. Extract Route
   const routes = [
-    { standard: "po", variations: ["po", "oral", "by mouth"] }, { standard: "sl", variations: ["sl", "sublingual"] },
+    { standard: "po", variations: ["po", "oral", "by mouth"] }, { standard: "sl", variations: ["sl", "sublingual", "sublingually"] },
     { standard: "buccal", variations: ["buccal"] }, { standard: "pr", variations: ["pr", "rectal", "rectally"] },
     { standard: "ng", variations: ["ng", "nasogastric", "ng tube"] }, { standard: "og", variations: ["og", "orogastric"] },
     { standard: "gastrostomy", variations: ["gastrostomy", "g-tube", "peg tube"] }, { standard: "jejunostomy", variations: ["jejunostomy", "j-tube"] },

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -38,4 +38,14 @@ describe('Medication comparison', () => {
     const result = ctx.getChangeReason(p1, p2);
     expect(result).toBe('Indication changed');
   });
+
+  test('route change from oral to sublingually detected', () => {
+    const ctx = loadAppContext();
+    const before = 'Ondansetron 4 mg po q4h';
+    const after = 'Ondansetron 4 mg sublingually q4h';
+    const p1 = ctx.parseOrder(before);
+    const p2 = ctx.parseOrder(after);
+    const result = ctx.getChangeReason(p1, p2);
+    expect(result).toBe('Route changed');
+  });
 });


### PR DESCRIPTION
## Summary
- map `sublingually` to canonical `sl` route
- test that oral vs. sublingually is detected as a route change

## Testing
- `node tests/runTests.js`