### PR TITLE
Add brand/generic diff detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -2255,16 +2255,28 @@ function getChangeReason(orig, updated) {
   if (!endDateMatch) add('End Date changed');
 
 // --- Brand/Generic Change ---
-// Check if normalized names (substance) are same, but raw inputs were different,
-// or if one is a known brand of the other.
+// Flag when raw names differ but they resolve to the same active ingredient,
+// or when different generics map to a known brand/generic pairing.
 const origCoreBrandCheck = origDrugNameRaw.split(' ')[0].toLowerCase();
 const updatedCoreBrandCheck = updatedDrugNameRaw.split(' ')[0].toLowerCase();
-const origGenericMapped = normalizeMedicationName(brandToGenericMap[origCoreBrandCheck] || origDrugNameRaw);
-const updatedGenericMapped = normalizeMedicationName(brandToGenericMap[updatedCoreBrandCheck] || updatedDrugNameRaw);
+const origGenericMapped = normalizeMedicationName(
+  brandToGenericMap[origCoreBrandCheck] || origDrugNameRaw
+);
+const updatedGenericMapped = normalizeMedicationName(
+  brandToGenericMap[updatedCoreBrandCheck] || updatedDrugNameRaw
+);
+const rawNamesDiffer =
+  origDrugNameRaw.toLowerCase().trim() !==
+  updatedDrugNameRaw.toLowerCase().trim();
+const genericsEqual = origGenericMapped === updatedGenericMapped;
 
-if (origGenericMapped !== updatedGenericMapped &&
-   (brandToGenericMap[origCoreBrandCheck] || brandToGenericMap[updatedCoreBrandCheck])) {
-    add('Brand/Generic changed');
+if (
+  (genericsEqual && rawNamesDiffer) ||
+  (!genericsEqual &&
+    (brandToGenericMap[origCoreBrandCheck] ||
+      brandToGenericMap[updatedCoreBrandCheck]))
+) {
+  add('Brand/Generic changed');
 }
 
 

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -47,7 +47,7 @@ require('./medDiff.test');
 addTest('Insulin before-meals equals TIDAC dose & freq change', () => {
   const before = 'Insulin Aspart (Novolog) FlexPen - Inject 10 units subcutaneously TIDAC';
   const after = 'Novolog FlexPen - Inject 12 units SC before meals (breakfast lunch dinner)';
-  expect(diff(before, after)).toBe('Dose changed, Frequency changed');
+  expect(diff(before, after)).toBe('Dose changed, Frequency changed, Brand/Generic changed');
 });
 
 addTest('Metformin evening vs nightly time change', () => {
@@ -59,7 +59,7 @@ addTest('Metformin evening vs nightly time change', () => {
 addTest('Vitamin D brand/generic without formulation change', () => {
   const before = 'Cholecalciferol 5000 IU softgel - One weekly';
   const after = 'Vitamin D3 2000 units capsule - One daily';
-  expect(diff(before, after)).toBe('Dose changed, Frequency changed, Form changed');
+  expect(diff(before, after)).toBe('Multiple changes');
 });
 
 addTest('Fluticasone spray dose total', () => {
@@ -80,3 +80,8 @@ addTest('Warfarin qPM vs evening flagged', () => {
   expect(diff(before, after)).toBe('Time of day changed');
 });
 
+addTest('Insulin Aspart vs Novolog brand generic detection', () => {
+  const before = 'Insulin Aspart 10 units SC daily';
+  const after = 'Novolog 10 units SC daily';
+  expect(diff(before, after)).toBe('Brand/Generic changed');
+});


### PR DESCRIPTION
## Summary
- handle brand vs generic when raw names differ
- adjust brand/generic tests
- add regression test for insulin brand name

## Testing
- `npm test`