### PR TITLE
Add Novolog brand name diff test

### DIFF
--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -91,3 +91,9 @@ addTest('PRN condition wording change detected', () => {
   const after = 'Alprazolam 0.5mg tablet - take 1 tab q8h if anxious';
   expect(diff(before, after)).toBe('PRN changed');
 });
+
+addTest('Novolog brand name flagged', () => {
+  const before = 'Insulin Aspart (Novolog) FlexPen - Inject 10 units subcutaneously TIDAC';
+  const after = 'Novolog FlexPen - Inject 12 units SC before meals (breakfast lunch dinner)';
+  expect(diff(before, after)).toBe('Dose changed, Frequency changed, Brand/Generic changed');
+});


### PR DESCRIPTION
## Summary
- add a new test for Novolog brand name detection

## Testing
- `npx prettier tests/runTests.js`
- `npx eslint tests/runTests.js` *(fails: couldn't find configuration file)*
- `npm test`