### PR TITLE
Add test for Fluticasone formulation + update detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -2669,7 +2669,7 @@ const formulationKeywords = [
     'modified release', 'delayed release', 'extended release', 'controlled release', // Multi-word first
     'xr', 'er', 'sr', 'la', 'xl', 'cr', 'dr',
     'succinate', 'tartrate', 'maleate', 'fumarate', 'besylate', 'camsylate', 'mesylate',
-    'acetate', 'phosphate', 'carbonate', 'gluconate', 'sodium', 'hydrochloride'
+    'acetate', 'phosphate', 'carbonate', 'gluconate', 'propionate', 'sodium', 'hydrochloride'
 ].sort((a, b) => b.length - a.length); // Sort by length, longest first is crucial
 
 let processedOrderStrForFormulation = orderStr; // Work on a copy

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -65,13 +65,19 @@ addTest('Vitamin D brand/generic without formulation change', () => {
 addTest('Fluticasone spray dose total', () => {
   const before = 'Fluticasone Propionate Nasal Spray 50 mcg/spray - 2 sprays in each nostril once daily';
   const after = 'Fluticasone Nasal Spray 50mcg - Use 1 spray per nostril qd';
-  expect(diff(before, after)).toBe('Quantity changed');
+  expect(diff(before, after)).toBe('Formulation changed, Quantity changed');
 });
 
 addTest('Fluticasone quantity change', () => {
   const before = 'Fluticasone Propionate Nasal Spray 50 mcg/spray – 2 sprays in each nostril daily';
   const after = 'Fluticasone Nasal Spray 50 mcg – 1 spray per nostril qd';
-  expect(diff(before, after)).toBe('Quantity changed');
+  expect(diff(before, after)).toBe('Formulation changed, Quantity changed');
+});
+
+addTest('Fluticasone formulation flagged', () => {
+  const before = 'Fluticasone Propionate Nasal Spray 50 mcg/spray – 2 sprays each nostril daily';
+  const after = 'Fluticasone Nasal Spray 50 mcg – 1 spray per nostril qd';
+  expect(diff(before, after)).toBe('Formulation changed, Quantity changed');
 });
 
 addTest('Warfarin sodium formulation difference', () => {


### PR DESCRIPTION
## Summary
- detect `propionate` as a formulation keyword
- update Fluticasone tests to include formulation change
- add new test case ensuring formulation changes are flagged

## Testing
- `npm test`