### PR TITLE
Handle AF abbreviation and refine indication comparisons

### DIFF
--- a/index.html
+++ b/index.html
@@ -2111,9 +2111,10 @@ function normalizeIndicationText(txt = '') {
              .trim();
 
   const synonyms = {
-    'afib':'atrial fibrillation',
-    'a fib':'atrial fibrillation',
-    'atrial fib':'atrial fibrillation',
+    'afib': 'atrial fibrillation',
+    'af': 'atrial fibrillation',
+    'a fib': 'atrial fibrillation',
+    'atrial fib': 'atrial fibrillation',
     'sob':'breathing difficulty',
     'shortness of breath':'breathing difficulty',
     'anxious':'anxiety'
@@ -4183,11 +4184,13 @@ if (!match) {
         // very novice-friendly override for “only indication” cases
         const origInd = (r.parsed.indication || '').toLowerCase().trim();
         const newInd  = (match.parsed.indication || '').toLowerCase().trim();
+        const normOrig = normalizeIndicationText(origInd);
+        const normNew  = normalizeIndicationText(newInd);
         if (
             normalizeMedicationName(r.parsed.drug) === normalizeMedicationName(match.parsed.drug)
             && r.parsed.dose.value === match.parsed.dose.value
             && r.parsed.dose.unit  === match.parsed.dose.unit
-            && origInd !== newInd
+            && normOrig !== normNew
         ) {
             changeType = 'Indication changed';
         }
@@ -4202,8 +4205,9 @@ if (!match) {
    if (match && (changeType === 'Generic Medication' || changeType === 'Brand Medication')) {
      // build a list of reasons
      const reasons = [ changeType ];
-     if ((r.parsed.indication || '').toLowerCase().trim()
-       !== (match.parsed.indication || '').toLowerCase().trim()) {
+     const ind1 = normalizeIndicationText((r.parsed.indication || '').toLowerCase().trim());
+     const ind2 = normalizeIndicationText((match.parsed.indication || '').toLowerCase().trim());
+     if (ind1 !== ind2) {
        reasons.push('Indication changed');
      }
             html += `

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -48,4 +48,14 @@ describe('Medication comparison', () => {
     const result = ctx.getChangeReason(p1, p2);
     expect(result).toBe('Route changed');
   });
+
+  test('af vs atrial fibrillation not flagged', () => {
+    const ctx = loadAppContext();
+    const before = 'Metoprolol 50 mg tablet - take 1 tab daily for af';
+    const after = 'Metoprolol 50 mg tablet - take 1 tab daily for atrial fibrillation';
+    const p1 = ctx.parseOrder(before);
+    const p2 = ctx.parseOrder(after);
+    const result = ctx.getChangeReason(p1, p2);
+    expect(result).toBe('Unchanged');
+  });
 });

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -129,3 +129,9 @@ addTest('Clonidine enumerate changes', () => {
     'Frequency changed, Brand/Generic changed, Route changed, Form changed'
   );
 });
+
+addTest('AF abbreviation normalized', () => {
+  const before = 'Metoprolol 50 mg tablet - take 1 tab daily for af';
+  const after = 'Metoprolol 50 mg tablet - take 1 tab daily for atrial fibrillation';
+  expect(diff(before, after)).toBe('Unchanged');
+});


### PR DESCRIPTION
## Summary
- normalize `af`/`afib` indication text to "atrial fibrillation"
- prevent `getChangeReason` from flagging indication changes when normalized text matches
- cover new scenario with tests

## Testing
- `npm test`