### PR TITLE
Add Spiriva synonyms & adjust test

### DIFF
--- a/index.html
+++ b/index.html
@@ -1704,6 +1704,15 @@ const commonIndicationsPatterns = [
       n = n.replace(re, brandToGenericMap[brand]);
     }
 
+    const brandSynonyms = {
+      spiriva: 'tiotropium',
+      'tiotropium bromide': 'tiotropium'
+    };
+    for (const syn in brandSynonyms) {
+      const reSyn = new RegExp('\\b' + syn + '\\b', 'gi');
+      n = n.replace(reSyn, brandSynonyms[syn]);
+    }
+
     /* 2 .  Strip common salt words */
     const commonSalts = [
       'hydrochloride', 'hcl',
@@ -1728,7 +1737,7 @@ const commonIndicationsPatterns = [
 
     /* 4. Remove common leftover instructional/form words and numbers from name string */
     n = n.replace(/\b\d+(?:\.\d+)?\b/g, '');
-    n = n.replace(/\b(?:tablet|tablets|tab|tabs|cap|capsule|capsules|caplet|oral|po|subq|sc|im|iv|id|pr|sl|os|od|au|oin|oint|ophth|neb|inh|inj|inject|supp|sol|solution|susp|elix|syr|tr|tinct|lot|crm|crm.|ung|gel|aero|conc|dil|dp|ds|emuls|enema|er|film|gas|gran|gum|impl|inf|ins|irrig|jec|liq|lotn|loz|mdi|mis|nebu|oint|oph|pad|part|pas|past|pel|pen|pill|plst|powd|pwd|rinse|sat|shamp|soak|spg|spl|spray|stk|strip|subl|sup|swab|syr|sys|tab|tamp|tape|top|troche|twa|vag|wafer|xt|xr|xl|xd|sr|cr|dr|la|patch|puffs|drops|lozenge|spray|unit|units|ml|mcg|mg|g|solostar)\b/gi, '');
+    n = n.replace(/\b(?:tablet|tablets|tab|tabs|cap|capsule|capsules|caplet|oral|po|subq|sc|im|iv|id|pr|sl|os|od|au|oin|oint|ophth|neb|inh|inj|inject|supp|sol|solution|susp|elix|syr|tr|tinct|lot|crm|crm.|ung|gel|aero|conc|dil|dp|ds|emuls|enema|er|film|gas|gran|gum|impl|inf|ins|irrig|jec|liq|lotn|loz|mdi|mis|nebu|oint|oph|pad|part|pas|past|pel|pen|pill|plst|powd|pwd|rinse|sat|shamp|soak|spg|spl|spray|stk|strip|subl|sup|swab|syr|sys|tab|tamp|tape|top|troche|twa|vag|wafer|xt|xr|xl|xd|sr|cr|dr|la|patch|puffs|drops|lozenge|spray|unit|units|ml|mcg|mg|g|solostar|actuation)\b/gi, '');
 
     /* 5. Final cleanup */
     n = n.replace(/[\/\-]/g, ' ')

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -25,7 +25,7 @@ describe('Medication comparison', () => {
     const p1 = ctx.parseOrder(before);
     const p2 = ctx.parseOrder(after);
     const result = ctx.getChangeReason(p1, p2);
-    expect(result).toBe('Dose changed, Form changed');
+    expect(result).toBe('Dose changed, Brand/Generic changed, Form changed');
   });
 
   test('adding nerve pain indication detected', () => {


### PR DESCRIPTION
## Summary
- normalize Spiriva handihaler/respimat to tiotropium by adding `brandSynonyms`
- ignore the word `actuation` when cleaning drug names
- expect brand/generic change in Spiriva Respimat vs Tiotropium HandiHaler test

## Testing
- `npm test`