### PR TITLE
Add device word cleanup for inhalers

### DIFF
--- a/index.html
+++ b/index.html
@@ -3329,6 +3329,11 @@ if (orderStr.length > 0) {
     }
 }
 
+// Strip common inhaler device terms that can trail the drug name
+const deviceWords = /\b(respimat|handihaler|actuation|flexpen|pen|diskus)\b/i;
+orderStr = orderStr.replace(deviceWords, '').replace(/\/\s*$/, '').trim();
+finalDrugName = finalDrugName.replace(deviceWords, '').replace(/\/\s*$/, '').trim();
+
 // Assign to order object
 order.drug = finalDrugName.replace(/[^a-zA-Z0-9\/\s\-\.#]+/g, ' ') // Allow # for Tylenol #3
                          .replace(/\s\s+/g, ' ')

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -135,3 +135,12 @@ addTest('AF abbreviation normalized', () => {
   const after = 'Metoprolol 50 mg tablet - take 1 tab daily for atrial fibrillation';
   expect(diff(before, after)).toBe('Unchanged');
 });
+
+addTest('Spiriva brand/generic flag', () => {
+  const before =
+    'Tiotropium Bromide (Spiriva HandiHaler) 18mcg capsule - Inhale contents of one capsule via HandiHaler once daily';
+  const after =
+    'Spiriva Respimat 2.5mcg/actuation - 2 inhalations once daily';
+  expect(diff(before, after))
+    .toBe('Dose changed, Brand/Generic changed, Form changed');
+});


### PR DESCRIPTION
## Summary
- strip common device terms like *Respimat* and *HandiHaler* when parsing orders so brand/generic detection works
- verify Spiriva vs Tiotropium now reports brand/generic change

## Testing
- `npm test`