### PR TITLE
Restore brand synonym logic and tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -1653,6 +1653,8 @@ function hasContra(orderObj, wholeList = []) {
   const brandSynonyms = {
     spiriva: 'tiotropium',
     'tiotropium bromide': 'tiotropium',
+    novolog: 'insulin aspart',
+    humalog: 'insulin lispro',
     hctz: 'hydrochlorothiazide'
   };
 
@@ -1661,6 +1663,7 @@ function hasContra(orderObj, wholeList = []) {
     hctz: 'hydrochlorothiazide',
     hydrochlorothiazide: 'hydrochlorothiazide'
   };
+  genericSynonyms['tiotropium bromide'] = 'tiotropium';
 
 const commonIndicationsPatterns = [
     { pattern: /(hypertension)$/i, indication: "hypertension" },
@@ -2338,13 +2341,19 @@ function getChangeReason(orig, updated) {
   };
   const rawNamesDiffer =
     cleanForBG(origDrugNameRaw) !== cleanForBG(updatedDrugNameRaw);
-  const hasBrandToken = name =>
-    Object.keys(brandSynonyms).some(
-      tok => tok.length > 4 && brandToGenericMap[tok] && name.includes(tok)
-    );
+  const normRaw = str => {
+    let s = str.toLowerCase();
+    Object.entries(genericSynonyms).forEach(([abbr, full]) => {
+      s = s.replace(new RegExp('\\b' + abbr + '\\b', 'g'), full);
+    });
+    return s;
+  };
+  const leftRaw = normRaw(origDrugNameRaw);
+  const rightRaw = normRaw(updatedDrugNameRaw);
+  const leftHasBrand = Object.keys(brandSynonyms).some(t => leftRaw.includes(t));
+  const rightHasBrand = Object.keys(brandSynonyms).some(t => rightRaw.includes(t));
   if (drugNameMatchStrict) {
-    const brandSwitch =
-      hasBrandToken(origDrugNameRaw) !== hasBrandToken(updatedDrugNameRaw);
+    const brandSwitch = leftHasBrand !== rightHasBrand;
     if (brandSwitch && !changes.includes('Brand/Generic changed')) {
       changes.push('Brand/Generic changed');
     }

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -47,7 +47,7 @@ require('./medDiff.test');
 addTest('Insulin before-meals equals TIDAC dose & freq change', () => {
   const before = 'Insulin Aspart (Novolog) FlexPen - Inject 10 units subcutaneously TIDAC';
   const after = 'Novolog FlexPen - Inject 12 units SC before meals (breakfast lunch dinner)';
-  expect(diff(before, after)).toBe('Dose changed, Frequency changed');
+  expect(diff(before, after)).toBe('Dose changed, Frequency changed, Brand/Generic changed');
 });
 
 addTest('Metformin evening vs nightly time change', () => {
@@ -95,7 +95,7 @@ addTest('Warfarin qPM vs evening flagged', () => {
 addTest('Insulin Aspart vs Novolog brand generic detection', () => {
   const before = 'Insulin Aspart 10 units SC daily';
   const after = 'Novolog 10 units SC daily';
-  expect(diff(before, after)).toBe('Unchanged');
+  expect(diff(before, after)).toBe('Brand/Generic changed');
 });
 
 addTest('PRN condition wording change detected', () => {
@@ -113,7 +113,7 @@ addTest('Alprazolam PRN change detected', () => {
 addTest('Novolog brand name flagged', () => {
   const before = 'Insulin Aspart (Novolog) FlexPen - Inject 10 units subcutaneously TIDAC';
   const after = 'Novolog FlexPen - Inject 12 units SC before meals (breakfast lunch dinner)';
-  expect(diff(before, after)).toBe('Dose changed, Frequency changed');
+  expect(diff(before, after)).toBe('Dose changed, Frequency changed, Brand/Generic changed');
 });
 
 addTest('Vitamin D change list enumerated', () => {


### PR DESCRIPTION
## Summary
- add back brand synonyms for Novolog/Humalog and others
- normalize raw drug names before brand/generic comparison
- expand generic synonyms
- update tests for insulin brand/generic detection

## Testing
- `npm test`