### PR TITLE
Normalize TID synonyms

### DIFF
--- a/index.html
+++ b/index.html
@@ -2173,6 +2173,14 @@ function normalizeTimeOfDay(t) {
   return t;
 }
 
+function normalizeFrequency(str) {
+  if (!str) return '';
+  str = str.toLowerCase().trim();
+  const tidPattern = /\b(tidac|tid\b|three\s+times\s+daily|3\s+times\s+daily|before\s+meals?)\b/;
+  if (tidPattern.test(str)) return 'tid';   // canonical label
+  return str;
+}
+
 // <<< START OF WHERE YOU PASTE THE NEW FUNCTION >>>
 function inhaled(parsedOrder) {
     if (!parsedOrder) return false;
@@ -2396,7 +2404,9 @@ if (!frequencyMatch) {
     }
 } else if (!tokensEqual(orig.frequencyTokens, updated.frequencyTokens) &&
            (containsMeals(orig.frequencyTokens) || containsMeals(updated.frequencyTokens))) {
-    add('Frequency changed');
+    if (!(canon(orig.frequency) === 'tid' && canon(updated.frequency) === 'tid')) {
+      add('Frequency changed');
+    }
 }
 
 // --- Time of Day Change ---
@@ -3246,10 +3256,11 @@ if (!order.frequency) { // <<<< ADD THIS OPENING 'if' and its brace
 }
 }
 // ... (end of Step 8 for frequency parsing)
-  if (!order.frequency && order.timeOfDay) {
-    order.frequency = 'daily';
-  }
-  // console.log(`DEBUG parseOrder Step 8 (Frequency): order.frequency="${order.frequency}", orderStr="${orderStr}"`);
+  if (!order.frequency && order.timeOfDay) {
+    order.frequency = 'daily';
+  }
+  order.frequency = normalizeFrequency(order.frequency);
+  // console.log(`DEBUG parseOrder Step 8 (Frequency): order.frequency="${order.frequency}", orderStr="${orderStr}"`);
 
 // --- // --- START OF REVISED AND ENHANCED STEP 9 ---
 // 9. Final Drug Name and Indication Assignment from remaining orderStr

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -44,12 +44,6 @@ function diff(before, after) {
 
 require('./medDiff.test');
 
-addTest('Insulin before-meals equals TIDAC dose & freq change', () => {
-  const before = 'Insulin Aspart (Novolog) FlexPen - Inject 10 units subcutaneously TIDAC';
-  const after = 'Novolog FlexPen - Inject 12 units SC before meals (breakfast lunch dinner)';
-  expect(diff(before, after)).toBe('Dose changed, Frequency changed, Brand/Generic changed');
-});
-
 addTest('Metformin evening vs nightly time change', () => {
   const before = 'Metformin hydrochloride 1000mg ER - take one tablet by mouth every evening with supper';
   const after = 'Metformin ER 1000mg - take 1 tab PO nightly with food';
@@ -110,12 +104,6 @@ addTest('Alprazolam PRN change detected', () => {
   expect(diff(before, after)).toBe('Route changed, Form changed, PRN changed');
 });
 
-addTest('Novolog brand name flagged', () => {
-  const before = 'Insulin Aspart (Novolog) FlexPen - Inject 10 units subcutaneously TIDAC';
-  const after = 'Novolog FlexPen - Inject 12 units SC before meals (breakfast lunch dinner)';
-  expect(diff(before, after)).toBe('Dose changed, Frequency changed, Brand/Generic changed');
-});
-
 addTest('Vitamin D change list enumerated', () => {
   const before = 'Cholecalciferol 5000 IU softgel – One weekly';
   const after = 'Vitamin D3 2000 units capsule – One daily';
@@ -149,4 +137,10 @@ addTest('HCTZ abbreviation no brand flag', () => {
   const before = 'Lisinopril/HCTZ 20-12.5mg PO daily';
   const after  = 'Lisinopril 20mg / Hydrochlorothiazide 12.5mg PO daily';
   expect(diff(before, after)).toBe('Unchanged');
+});
+
+addTest('Insulin TIDAC equals before meals (no freq flag)', () => {
+  const before = 'Insulin Aspart (Novolog) FlexPen - Inject 10 units subcutaneously TIDAC';
+  const after  = 'Novolog FlexPen - Inject 12 units SC before meals (breakfast lunch dinner)';
+  expect(diff(before, after)).toBe('Dose changed, Brand/Generic changed');
 });


### PR DESCRIPTION
## Summary
- normalize three-times-daily phrases with `normalizeFrequency`
- apply frequency normalization inside `parseOrder`
- ignore meal token differences when frequencies normalize to `tid`
- update tests for insulin frequency handling

## Testing
- `npm test`