### PR TITLE
Ignore trivial salts in formulation comparison

### DIFF
--- a/index.html
+++ b/index.html
@@ -1659,6 +1659,7 @@ function hasContra(orderObj, wholeList = []) {
   };
 
   const ignoreSalts = /\b(hydrochloride|sulfate|phosphate|acetate|maleate|tartrate|mesylate|succinate|sodium|potassium|calcium|magnesium)\b/gi;
+  const trivialSalts = /\b(sodium|hydrochloride|sulfate|phosphate|acetate|succinate|maleate|tartrate|mesylate|potassium|calcium|magnesium)\b/gi;
 
   const importantSaltPairs = [
     ['diclofenac sodium',      'diclofenac potassium'],
@@ -2284,7 +2285,14 @@ function getChangeReason(orig, updated) {
     norm(updated.timeOfDayOriginal)
   );
   const formMatch = same(norm(orig.form), norm(updated.form));
-  const formulationMatch = same(norm(orig.formulation), norm(updated.formulation));
+  let formulationMatch = same(norm(orig.formulation), norm(updated.formulation));
+  // Re-evaluate formulationMatch minus trivial salts
+  const normForm = (f) => (f || '').replace(trivialSalts, '').replace(/\s{2,}/g,'').trim();
+  if ( !formulationMatch && normForm(orig.formulation) === normForm(updated.formulation) ) {
+    formulationMatch = true;
+    // remove the tag if it was added earlier
+    changes = changes.filter(c => c !== 'Formulation changed');
+  }
   const routeMatch = same(norm(orig.route), norm(updated.route));
   const prnMatch = same(orig.prn, updated.prn);
   const simpleNorm = s => (s || '').toLowerCase().replace(/\s+/g, ' ').trim();
@@ -2374,9 +2382,11 @@ function getChangeReason(orig, updated) {
     if (brandSwitch && !changes.includes('Brand/Generic changed')) {
       changes.push('Brand/Generic changed');
     }
+    const leftFull  = `${origDrugNameRaw} ${orig.formulation || ''}`.trim();
+    const rightFull = `${updatedDrugNameRaw} ${updated.formulation || ''}`.trim();
     const saltSwap = importantSaltPairs.some(([a, b]) =>
-      (origDrugNameRaw.includes(a) && updatedDrugNameRaw.includes(b)) ||
-      (origDrugNameRaw.includes(b) && updatedDrugNameRaw.includes(a))
+      (leftFull.includes(a) && rightFull.includes(b)) ||
+      (leftFull.includes(b) && rightFull.includes(a))
     );
     if (saltSwap && !changes.includes('Formulation changed')) {
       changes.push('Formulation changed');

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -47,7 +47,7 @@ require('./medDiff.test');
 addTest('Metformin evening vs nightly time change', () => {
   const before = 'Metformin hydrochloride 1000mg ER - take one tablet by mouth every evening with supper';
   const after = 'Metformin ER 1000mg - take 1 tab PO nightly with food';
-  expect(diff(before, after)).toBe('Formulation changed');
+  expect(diff(before, after)).toBe('Unchanged');
 });
 
 addTest('Vitamin D brand/generic without formulation change', () => {
@@ -77,7 +77,7 @@ addTest('Fluticasone formulation flagged', () => {
 addTest('Warfarin sodium formulation difference', () => {
   const before = 'Warfarin sodium 5 mg tablet - take one daily';
   const after = 'Warfarin 5 mg tablet - take one daily';
-  expect(diff(before, after)).toBe('Formulation changed');
+  expect(diff(before, after)).toBe('Unchanged');
 });
 
 addTest('Warfarin qPM vs evening flagged', () => {
@@ -155,4 +155,16 @@ addTest('Diclofenac sodium vs potassium flags formulation', () => {
   const before = 'Diclofenac sodium 50 mg tablet PO BID';
   const after  = 'Diclofenac potassium 50 mg tablet PO BID';
   expect(diff(before, after)).toBe('Formulation changed');
+});
+
+addTest('Warfarin sodium vs warfarin unchanged', () => {
+  const before = 'Warfarin sodium 5 mg tablet po evening';
+  const after  = 'Warfarin 5 mg tablet po qpm';
+  expect(diff(before, after)).toBe('Unchanged');
+});
+
+addTest('Metformin HCl ER vs Metformin ER unchanged', () => {
+  const b = 'Metformin hydrochloride 1000 mg ER tablet nightly';
+  const a = 'Metformin ER 1000 mg tablet evening';
+  expect(diff(b, a)).toBe('Unchanged');
 });


### PR DESCRIPTION
## Summary
- ignore common salts when comparing formulations
- detect important salt changes even if salt appears in drug name
- expect unchanged results for trivial salt differences
- add regression tests for warfarin & metformin salt handling

## Testing
- `npm test`