### PR TITLE
Add test for diffRows sorting

### DIFF
--- a/index.html
+++ b/index.html
@@ -3673,13 +3673,24 @@ for (let i = removed.length - 1; i >= 0; i--) {
       unchanged.forEach(pair => {
         const reason = getChangeReason(pair.orig.parsed, pair.new.parsed);
         const label = reason === 'Misc. Change' ? 'Unchanged' : reason;
-        rows.push({ orig: pair.orig.original, new: pair.new.original, changes: label });
+        rows.push({
+          orig: pair.orig.original,
+          new: pair.new.original,
+          changes: label === 'Unchanged' ? [] : [label]
+        });
       });
       removed.forEach(r => {
-        rows.push({ orig: r.original, new: '', changes: 'Removed' });
+        rows.push({ orig: r.original, new: '', changes: ['Removed'] });
       });
       added.forEach(a => {
-        rows.push({ orig: '', new: a.original, changes: 'Added' });
+        rows.push({ orig: '', new: a.original, changes: ['Added'] });
+      });
+
+      rows.sort((a, b) => {
+        const aUnchanged = a.changes.length === 0;
+        const bUnchanged = b.changes.length === 0;
+        if (aUnchanged === bUnchanged) return 0;
+        return aUnchanged ? 1 : -1;
       });
 
       return rows;

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -16,6 +16,27 @@ global.expect = actual => ({
     if (actual !== expected) {
       throw new Error(`Expected ${expected} but received ${actual}`);
     }
+  },
+  toEqual: expected => {
+    const a = JSON.stringify(actual);
+    const b = JSON.stringify(expected);
+    if (a !== b) {
+      throw new Error(`Expected ${b} but received ${a}`);
+    }
+  },
+  not: {
+    toEqual: expected => {
+      const a = JSON.stringify(actual);
+      const b = JSON.stringify(expected);
+      if (a === b) {
+        throw new Error(`Expected value not equal to ${b}`);
+      }
+    },
+    toBe: expected => {
+      if (actual === expected) {
+        throw new Error(`Expected value not to be ${expected}`);
+      }
+    }
   }
 });
 
@@ -57,6 +78,7 @@ function diffRowsList(beforeList, afterList) {
 }
 
 global.diffRowsList = diffRowsList;
+global.diffRows = diffRowsList;
 
 require('./medDiff.test');
 
@@ -195,4 +217,18 @@ addTest('Anxious vs anxiety = no indication flag', () => {
   const before = 'Alprazolam 0.25 mg ODT SL q6h prn anxiety';
   const after  = 'Alprazolam 0.25 mg tab PO every 6 hours if anxious';
   expect(diff(before, after)).toBe('Route changed, Form changed');
+});
+
+addTest('Unchanged rows sorted last', () => {
+  const listA = [
+    'Metformin 500 mg tab po bid',
+    'Amlodipine 5 mg tab po daily'
+  ].join('\n');
+  const listB = [
+    'Metformin 500 mg tab po bid',
+    'Amlodipine 10 mg tab po daily'
+  ].join('\n');
+  const rows = diffRows(listA, listB);
+  expect(rows[0].changes).not.toEqual([]);
+  expect(rows[rows.length - 1].changes).toEqual([]);
 });


### PR DESCRIPTION
## Summary
- extend simple test harness with `toEqual` and negation support
- expose `diffRows` helper for tests
- ensure `diffRows` returns change arrays and sorts unchanged last
- add test case for this behavior

## Testing
- `npm test`