### PR TITLE
Handle Klor-Con brand ER

### DIFF
--- a/index.html
+++ b/index.html
@@ -1661,6 +1661,7 @@ function hasContra(orderObj, wholeList = []) {
     lantus:         'insulin glargine',
     claritin:       'loratadine'
   };
+  brandSynonyms['klor-con'] = 'potassium chloride';
 
   const ignoreSalts = /\b(hydrochloride|sulfate|phosphate|acetate|maleate|tartrate|mesylate|succinate|propionate|sodium|potassium|calcium|magnesium)\b/gi;
   const trivialSalts = /\b(sodium|hydrochloride|sulfate|phosphate|acetate|succinate|maleate|tartrate|mesylate|propionate|potassium|calcium|magnesium)\b/gi;
@@ -1677,6 +1678,7 @@ function hasContra(orderObj, wholeList = []) {
     hydrochlorothiazide: 'hydrochlorothiazide'
   };
   genericSynonyms['tiotropium bromide'] = 'tiotropium';
+  genericSynonyms['kcl'] = 'potassium chloride';
 
 const commonIndicationsPatterns = [
     { pattern: /(hypertension)$/i, indication: "hypertension" },
@@ -1736,6 +1738,10 @@ const commonIndicationsPatterns = [
     for (const syn in brandSynonyms) {
       const reSyn = new RegExp('\\b' + syn + '\\b', 'gi');
       n = n.replace(reSyn, brandSynonyms[syn]);
+    }
+    for (const syn in genericSynonyms) {
+      const reSyn = new RegExp('\\b' + syn + '\\b', 'gi');
+      n = n.replace(reSyn, genericSynonyms[syn]);
     }
 
     /* 2 .  Strip common salt words */
@@ -2313,6 +2319,11 @@ function getChangeReason(orig, updated) {
   if ( !formulationMatch && normForm(orig.formulation) === normForm(updated.formulation) ) {
     formulationMatch = true;
     // remove the tag if it was added earlier
+    changes = changes.filter(c => c !== 'Formulation changed');
+  }
+  const stripER = f => (f || '').replace(/\ber\b/gi, '').trim();
+  if (!formulationMatch && stripER(orig.formulation) === stripER(updated.formulation)) {
+    formulationMatch = true;
     changes = changes.filter(c => c !== 'Formulation changed');
   }
   const routeMatch = same(norm(orig.route), norm(updated.route));

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -268,11 +268,17 @@ addTest('Solostar pen form same', () => {
 addTest('Twice daily with meals equals BID', () => {
   const b = 'KCl ER 10 mEq tab po twice a day with meals';
   const a = 'Klor-Con 10 mEq tab po BID';
-  expect(diff(b, a)).toBe('Formulation changed');
+  expect(diff(b, a)).toBe('Brand/Generic changed');
 });
 
 addTest('Claritin vs loratadine brand only', () => {
   const b = 'Claritin 10 mg tab po daily prn allergies';
   const a = 'Loratadine 10 mg tab po daily as needed for allergies';
   expect(diff(b, a)).toBe('Brand/Generic changed');
+});
+
+addTest('Klor-Con brand only', () => {
+  const b = 'Potassium Chloride ER 10 mEq tab po twice a day';
+  const a = 'Klor-Con 10 mEq tab po BID';
+  expect(diff(b,a)).toBe('Brand/Generic changed');
 });


### PR DESCRIPTION
## Summary
- recognize Klor-Con as a potassium chloride brand
- treat "KCl" abbreviation as potassium chloride for comparisons
- ignore ER wording when formulations otherwise match
- adjust potassium chloride expectations in tests
- cover new brand-only scenario in tests

## Testing
- `npm test`