### PR TITLE
Handle implicit tablet form

### DIFF
--- a/index.html
+++ b/index.html
@@ -2308,9 +2308,16 @@ function getChangeReason(orig, updated) {
     norm(orig.timeOfDayOriginal),
     norm(updated.timeOfDayOriginal)
   );
-  const formMatch = same(norm(orig.form), norm(updated.form));
+  let formMatch = same(norm(orig.form), norm(updated.form));
   if (!formMatch &&
       orig.form === 'pen' && updated.form === 'pen') {
+    formMatch = true;
+    changes = changes.filter(c => c !== 'Form changed');
+  }
+  if (!formMatch && (
+        (orig.form === '' && updated.form === 'tablet') ||
+        (updated.form === '' && orig.form === 'tablet')
+      )) {
     formMatch = true;
     changes = changes.filter(c => c !== 'Form changed');
   }

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -288,3 +288,10 @@ addTest('Tylenol brand flag', () => {
   const a = 'Acetaminophen 1000 mg tab PO every 6 hours as needed for pain';
   expect(diff(b, a)).toBe('Dose changed, Quantity changed, Brand/Generic changed');
 });
+
+addTest('Implicit tablet form same', () => {
+  const before = 'Tylenol 500 mg 2 tabs PO q6h prn pain';
+  const after  = 'Acetaminophen 1000 mg PO every 6 hours as needed for pain';
+  expect(diff(before, after))
+    .toBe('Dose changed, Quantity changed, Brand/Generic changed');
+});


### PR DESCRIPTION
## Summary
- treat an empty form as `tablet` when the other side explicitly says tablet
- add regression test for this case

## Testing
- `npm test`