### PR TITLE
Improve weekly frequency detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -2808,13 +2808,21 @@ for (const mapping of timeOfDayMappings) {
   }
 }
 
-// If a time of day was found (e.g. "morning") but frequency wasn't set by a specific shorthand (like qam, every morning)
-// then assume it's a daily frequency.
-if (order.timeOfDay && !order.frequency) {
-    order.frequency = 'daily';
-    // console.log(`DEBUG parseOrder Step 1 (Implied Daily Freq): tod="<span class="math-inline">\{order\.timeOfDay\}", freq\="</span>{order.frequency}"`);
-}
 
+// If a time of day was found (e.g. "morning") but frequency wasn't set by a specific shorthand (like qam, every morning)
+// then check for weekly-style phrases before assuming it's a daily frequency.
+if (order.timeOfDay && !order.frequency) {
+    const weeklyPattern = /\b(?:once\s+weekly|once\s+a\s+week|weekly|every\s+(?:mon(?:day)?|tue(?:sday)?|wed(?:nesday)?|thu(?:rsday)?|fri(?:day)?|sat(?:urday)?|sun(?:day)?))\b/i;
+    const weeklyMatch = orderStr.match(weeklyPattern);
+    if (weeklyMatch) {
+        order.frequency = 'weekly';
+        order.frequencyTokens.push(weeklyMatch[0].toLowerCase());
+        orderStr = orderStr.replace(weeklyMatch[0], '').trim();
+    } else {
+        order.frequency = 'daily';
+    }
+    // console.log(`DEBUG parseOrder Step 1 (Implied Freq): tod="${order.timeOfDay}", freq="${order.frequency}"`);
+}
 /* ——— NEW: capture “before / after breakfast|lunch|dinner”
           with an optional numeric offset ——— */
 if (!order.timeOfDay) {

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -313,3 +313,25 @@ addTest('Metoprolol XL vs ER unchanged', () => {
   const after  = 'Metoprolol Succinate ER 50 mg tab daily';
   expect(diff(before, after)).toBe('Unchanged');
 });
+
+addTest('Once weekly frequency detected', () => {
+  const ctxHtml = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const script = ctxHtml.split('<script>')[2].split('</script>')[0];
+  const ctx = { console: { log: () => {}, warn: () => {}, error: () => {} }, window: {}, document: { querySelectorAll: () => [], getElementById: () => ({}), addEventListener: () => {} }, firebase: { initializeApp: () => ({}), functions: () => ({ httpsCallable: () => () => ({}) }) } };
+  vm.createContext(ctx);
+  vm.runInContext(script, ctx);
+  const order = ctx.parseOrder('Vitamin D2 50000 units - take once weekly at bedtime');
+  expect(order.frequency).toBe('weekly');
+  expect(order.timeOfDay).toBe('bedtime');
+});
+
+addTest('Every Sunday morning parsed as weekly', () => {
+  const ctxHtml = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const script = ctxHtml.split('<script>')[2].split('</script>')[0];
+  const ctx = { console: { log: () => {}, warn: () => {}, error: () => {} }, window: {}, document: { querySelectorAll: () => [], getElementById: () => ({}), addEventListener: () => {} }, firebase: { initializeApp: () => ({}), functions: () => ({ httpsCallable: () => () => ({}) }) } };
+  vm.createContext(ctx);
+  vm.runInContext(script, ctx);
+  const order = ctx.parseOrder('Alendronate 70 mg tablet - take every Sunday morning');
+  expect(order.frequency).toBe('weekly');
+  expect(order.timeOfDay).toBe('morning');
+});


### PR DESCRIPTION
## Summary
- detect weekly phrases before defaulting to daily in `parseOrder`
- add tests for weekly phrasing

## Testing
- `npm test`