### PR TITLE
Centralize time-of-day aliases

### DIFF
--- a/index.html
+++ b/index.html
@@ -2193,31 +2193,36 @@ function normalizeIndication(txt) {
 
 function normalizeTimeOfDay(t) {
   if (!t) return '';
+  const aliases = {
+    morning: 'morning',
+    qam: 'morning',
+    am: 'morning',
+    'every am': 'morning',
+    'every morning': 'morning',
+    'in morning': 'morning',
+    'in the morning': 'morning',
+    'daily in morning': 'morning',
+    evening: 'evening',
+    pm: 'evening',
+    qpm: 'evening',
+    'every evening': 'evening',
+    'daily in evening': 'evening',
+    'in evening': 'evening',
+    'in the evening': 'evening',
+    'in the pm': 'evening',
+    bedtime: 'bedtime',
+    night: 'bedtime',
+    qhs: 'bedtime',
+    nightly: 'bedtime',
+    'at bedtime': 'bedtime',
+    'at night': 'bedtime',
+    'every night': 'bedtime'
+  };
   t = t.toLowerCase().trim();
-  if (
-    t === 'morning' ||
-    t === 'qam' ||
-    t === 'am' ||
-    t.includes('in morning') ||
-    t.includes('in the am')
-  )
-    return 'morning';
-  if (
-    t === 'evening' ||
-    t === 'pm' ||
-    t === 'qpm' ||
-    t.includes('every evening') ||
-    t.includes('daily in evening') ||
-    t.includes('in evening') ||
-    t.includes('in the pm') ||
-    t === 'bedtime' ||
-    t === 'night' ||
-    t === 'qhs' ||
-    t === 'nightly' ||
-    t.includes('at bedtime') ||
-    t.includes('at night')
-  )
-    return 'evening';
+  if (aliases[t]) return aliases[t];
+  for (const key in aliases) {
+    if (t.includes(key)) return aliases[key];
+  }
   return t;
 }
 

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -90,7 +90,7 @@ require('./medDiff.test');
 addTest('Metformin evening vs nightly time change', () => {
   const before = 'Metformin hydrochloride 1000mg ER - take one tablet by mouth every evening with supper';
   const after = 'Metformin ER 1000mg - take 1 tab PO nightly with food';
-  expect(diff(before, after)).toBe('Unchanged');
+  expect(diff(before, after)).toBe('Time of day changed');
 });
 
 addTest('Vitamin D brand/generic without formulation change', () => {
@@ -208,7 +208,7 @@ addTest('Warfarin sodium vs warfarin unchanged', () => {
 addTest('Metformin HCl ER vs Metformin ER unchanged', () => {
   const b = 'Metformin hydrochloride 1000 mg ER tablet nightly';
   const a = 'Metformin ER 1000 mg tablet evening';
-  expect(diff(b, a)).toBe('Unchanged');
+  expect(diff(b, a)).toBe('Time of day changed');
 });
 
 addTest('Fluticasone propionate omission not formulation', () => {


### PR DESCRIPTION
## Summary
- refactor `normalizeTimeOfDay` to use an alias map
- update tests for new bedtime semantics

## Testing
- `npm test`