### PR TITLE
Preserve raw dose units

### DIFF
--- a/index.html
+++ b/index.html
@@ -2322,7 +2322,10 @@ function getChangeReason(orig, updated) {
 
   const doseValueMatch = valuesEqual(orig.dose?.value, updated.dose?.value);
   const doseTotalMatch = valuesEqual((orig.dose?.total ?? orig.dose?.value), (updated.dose?.total ?? updated.dose?.value)); // Use total, fallback to value
-  const doseUnitMatch = same(orig.dose?.unit, updated.dose?.unit);
+  const doseUnitMatch = same(
+    orig.rawUnit || orig.dose?.unit,
+    updated.rawUnit || updated.dose?.unit
+  );
   const frequencyMatch = canon(orig.frequency) === canon(updated.frequency);
   const tokensEqual = (a,b) => {
     a = (a || []).map(norm).sort();
@@ -2697,7 +2700,8 @@ if (changes.includes('Frequency changed') && changes.includes('Time of day chang
     formulation: "",
     indication: "",
     brandTokens: [],
-    rawDrug: ""
+    rawDrug: "",
+    rawUnit: ""
   };
 // Store the initially cleaned drug string for later Brand/Generic comparison
   const initialCleanedDrugString = orderStr;
@@ -3085,6 +3089,7 @@ if (unitMatchesFound.length > 0) {
   const sprayHit = hits.find(h => h.stdUnit === 'spray');
   let unitLower = bestMatch.stdUnit.toLowerCase();
   if (unitLower === "gram") unitLower = "g";
+  order.rawUnit = unitLower; // store pre-normalization unit
   order.dose = { value: bestMatch.qty,
                  unit:  unitLower,
                  total: bestMatch.qty };

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -379,10 +379,22 @@ addTest('Microgram to milligram normalization', () => {
   const order = ctx.parseOrder('Levothyroxine 100 mcg tablet daily');
   expect(order.dose.value).toBe(0.1);
   expect(order.dose.unit).toBe('mg');
+  expect(order.rawUnit).toBe('mcg');
 });
 
 addTest('Vancomycin gram vs g unchanged', () => {
-  expect(diff('Vancomycin 1 gram q12h', 'Vancomycin 1 g q12h')).toBe('Unchanged');
+  const before = 'Vancomycin 1 gram q12h';
+  const after  = 'Vancomycin 1 g q12h';
+  const ctxHtml = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const script = ctxHtml.split('<script>')[2].split('</script>')[0];
+  const ctx = { console: { log: () => {}, warn: () => {}, error: () => {} }, window: {}, document: { querySelectorAll: () => [], getElementById: () => ({}), addEventListener: () => {} }, firebase: { initializeApp: () => ({}), functions: () => ({ httpsCallable: () => () => ({}) }) } };
+  vm.createContext(ctx);
+  vm.runInContext(script, ctx);
+  const p1 = ctx.parseOrder(before);
+  const p2 = ctx.parseOrder(after);
+  expect(p1.rawUnit).toBe('g');
+  expect(p2.rawUnit).toBe('g');
+  expect(ctx.getChangeReason(p1, p2)).toBe('Unchanged');
 });
 
 addTest('Synthroid brand detected', () => {


### PR DESCRIPTION
## Summary
- store original dose units as `rawUnit` during parsing
- compare `rawUnit` in `getChangeReason`
- keep `order.dose.unit` normalization while leaving `rawUnit` untouched
- test that raw units persist and unit comparison uses them

## Testing
- `npm test`