### PR TITLE
Handle taper phrasing in indications

### DIFF
--- a/index.html
+++ b/index.html
@@ -2191,6 +2191,7 @@ function normalizeIndication(txt) {
     .replace(/\bas needed\b/g, 'prn')
     .replace(/\binr\s*2\.?0?\s*-\s*3\.?0?\b/gi, 'inr 2-3')
     .replace(/\bfor sleep\b/i, 'sleep')
+    .replace(/\b(no\s+)?taper\b/gi, '')
     .trim();
 }
 

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -59,6 +59,17 @@ describe('Medication comparison', () => {
     expect(result).toBe('Unchanged');
   });
 
+  test('taper wording ignored in indications', () => {
+    const ctx = loadAppContext();
+    const before = 'Prednisone 20 mg tablet - take 1 tablet daily for asthma';
+    const after = 'Prednisone 20 mg tablet - take 1 tablet daily for asthma taper';
+    const p1 = ctx.parseOrder(before);
+    const p2 = ctx.parseOrder(after);
+    expect(p2.indication).toBe('asthma');
+    const result = ctx.getChangeReason(p1, p2);
+    expect(result).toBe('Unchanged');
+  });
+
   test('Clonidine patch to tablet not brand/generic', () => {
     const ctx = loadAppContext();
     const before = 'Clonidine 0.1 mg patch – Apply 1 patch topically every 7 days';


### PR DESCRIPTION
## Summary
- clean up taper phrases in indications
- ensure taper wording doesn't change comparison

## Testing
- `npm test`