### PR TITLE
Add debug flag to getChangeReason

### DIFF
--- a/index.html
+++ b/index.html
@@ -2270,9 +2270,12 @@ function inhaled(parsedOrder) {
 
 // ——— What changed? ———
 function getChangeReason(orig, updated) {
-  console.log('DEBUG getChangeReason: orig.drug=', orig.drug, 'updated.drug=', updated.drug);
-  console.log('DEBUG getChangeReason: orig Parsed=', JSON.stringify(orig));
-  console.log('DEBUG getChangeReason: updated Parsed=', JSON.stringify(updated));
+  const DEBUG_CHANGE_REASON = false;
+  if (DEBUG_CHANGE_REASON) {
+    console.log('DEBUG getChangeReason: orig.drug=', orig.drug, 'updated.drug=', updated.drug);
+    console.log('DEBUG getChangeReason: orig Parsed=', JSON.stringify(orig));
+    console.log('DEBUG getChangeReason: updated Parsed=', JSON.stringify(updated));
+  }
 
 // DEBUG getChangeReason: updated Parsed=', JSON.stringify(updated));
 // ── core/tail extractors for indication check ── // KEEP THIS COMMENT IF YOU WANT
@@ -2404,23 +2407,25 @@ function getChangeReason(orig, updated) {
 
 
   // --- Logging for debug ---
-  console.log('DEBUG getChangeReason - Comparisons:');
-  console.log('  drugNameMatchStrict (normalized substance):', drugNameMatchStrict, `(${origDrugNorm} vs ${updatedDrugNorm})`);
-  console.log('  origDrugNameRaw:', origDrugNameRaw, 'updatedDrugNameRaw:', updatedDrugNameRaw);
-  console.log('  formulationMatch:', formulationMatch, `(orig: ${norm(orig.formulation)} vs upd: ${norm(updated.formulation)})`);
-  console.log('  doseValueMatch (per unit):', doseValueMatch, `(orig: ${orig.dose?.value} vs upd: ${updated.dose?.value})`);
-  console.log('  doseTotalMatch:', doseTotalMatch, `(orig: ${orig.dose?.total ?? orig.dose?.value} vs upd: ${updated.dose?.total ?? updated.dose?.value})`);
-  console.log('  doseUnitMatch:', doseUnitMatch, `(orig: ${orig.dose?.unit} vs upd: ${updated.dose?.unit})`);
-  console.log('  qtyMatch:', qtyMatch, `(orig: ${(orig.qty ?? 1)} vs upd: ${(updated.qty ?? 1)})`);
-  console.log('  frequencyMatch:', frequencyMatch, `(orig: ${canon(orig.frequency)} vs upd: ${canon(updated.frequency)})`);
-  console.log('  timeOfDayMatch:', timeOfDayMatch, `(orig: ${norm(orig.timeOfDay)} vs upd: ${norm(updated.timeOfDay)})`);
-  console.log('  timeOfDayRawMatch:', timeOfDayRawMatch, `(orig: ${norm(orig.timeOfDayOriginal)} vs upd: ${norm(updated.timeOfDayOriginal)})`);
-  console.log('  formMatch:', formMatch, `(orig: ${norm(orig.form)} vs upd: ${norm(updated.form)})`);
-  console.log('  routeMatch:', routeMatch, `(orig: ${norm(orig.route)} vs upd: ${norm(updated.route)})`);
-  console.log('  prnMatch:', prnMatch, `(orig: ${orig.prn} vs upd: ${updated.prn})`);
-  console.log('  indicationDiff:', indicationDiff, `(${normInd(orig.indication)} vs ${normInd(updated.indication)})`);
-  console.log('  startDateMatch:', startDateMatch, `(orig: ${orig.startDate || ""} vs upd: ${updated.startDate || ""})`);
-  console.log('  endDateMatch:', endDateMatch, `(orig: ${orig.endDate || ""} vs upd: ${updated.endDate || ""})`);
+  if (DEBUG_CHANGE_REASON) {
+    console.log('DEBUG getChangeReason - Comparisons:');
+    console.log('  drugNameMatchStrict (normalized substance):', drugNameMatchStrict, `(${origDrugNorm} vs ${updatedDrugNorm})`);
+    console.log('  origDrugNameRaw:', origDrugNameRaw, 'updatedDrugNameRaw:', updatedDrugNameRaw);
+    console.log('  formulationMatch:', formulationMatch, `(orig: ${norm(orig.formulation)} vs upd: ${norm(updated.formulation)})`);
+    console.log('  doseValueMatch (per unit):', doseValueMatch, `(orig: ${orig.dose?.value} vs upd: ${updated.dose?.value})`);
+    console.log('  doseTotalMatch:', doseTotalMatch, `(orig: ${orig.dose?.total ?? orig.dose?.value} vs upd: ${updated.dose?.total ?? updated.dose?.value})`);
+    console.log('  doseUnitMatch:', doseUnitMatch, `(orig: ${orig.dose?.unit} vs upd: ${updated.dose?.unit})`);
+    console.log('  qtyMatch:', qtyMatch, `(orig: ${(orig.qty ?? 1)} vs upd: ${(updated.qty ?? 1)})`);
+    console.log('  frequencyMatch:', frequencyMatch, `(orig: ${canon(orig.frequency)} vs upd: ${canon(updated.frequency)})`);
+    console.log('  timeOfDayMatch:', timeOfDayMatch, `(orig: ${norm(orig.timeOfDay)} vs upd: ${norm(updated.timeOfDay)})`);
+    console.log('  timeOfDayRawMatch:', timeOfDayRawMatch, `(orig: ${norm(orig.timeOfDayOriginal)} vs upd: ${norm(updated.timeOfDayOriginal)})`);
+    console.log('  formMatch:', formMatch, `(orig: ${norm(orig.form)} vs upd: ${norm(updated.form)})`);
+    console.log('  routeMatch:', routeMatch, `(orig: ${norm(orig.route)} vs upd: ${norm(updated.route)})`);
+    console.log('  prnMatch:', prnMatch, `(orig: ${orig.prn} vs upd: ${updated.prn})`);
+    console.log('  indicationDiff:', indicationDiff, `(${normInd(orig.indication)} vs ${normInd(updated.indication)})`);
+    console.log('  startDateMatch:', startDateMatch, `(orig: ${orig.startDate || ""} vs upd: ${updated.startDate || ""})`);
+    console.log('  endDateMatch:', endDateMatch, `(orig: ${orig.endDate || ""} vs upd: ${updated.endDate || ""})`);
+  }
 
  // --- End Debugging Conditions ---
 
@@ -2565,7 +2570,7 @@ if (indicationDiff) {
     endDateMatch &&       // Check end date
     indicationDiff        // And indication IS different (and was the only difference)
   ) {
-    console.log('DEBUG: Matched Indication-only block (all other key fields identical).');
+  if (DEBUG_CHANGE_REASON) console.log('DEBUG: Matched Indication-only block (all other key fields identical).');
     // If ONLY the indication is different and everything else critical matches,
     // this specific block ensures 'Indication changed' is the primary (or only) reason.
     changes = ['Indication changed']; 
@@ -2573,7 +2578,7 @@ if (indicationDiff) {
     // This 'else' is for the if statement immediately above.
     // It means it wasn't a strict "Indication-only" change according to these specific criteria.
     // The broader change detection logic that ran before this block would have already added various changes.
-    console.log('DEBUG: Did NOT match strict Indication-only block; other changes might apply or already captured.');
+    if (DEBUG_CHANGE_REASON) console.log('DEBUG: Did NOT match strict Indication-only block; other changes might apply or already captured.');
 }
 
    // ——— 3) Time-of-day-only, but allow QOD→daily ———
@@ -2600,13 +2605,13 @@ if (
   endDateMatch &&       // <-- ADD
   normInd(orig.indication) === normInd(updated.indication)
 ) {
-  console.log("--- BLOCK #3 CONDITION MET --- Returning 'Time of day changed'");
+  if (DEBUG_CHANGE_REASON) console.log("--- BLOCK #3 CONDITION MET --- Returning 'Time of day changed'");
   changes = ['Time of day changed']; // Override other changes if this specific condition is met
 //  return 'Time of day changed'; // Old return
 }
 // ADD THIS ELSE BLOCK TO YOUR EXISTING IF
 else {
-  console.log("--- BLOCK #3 CONDITION FAILED for explicit Time of Day return ---");
+  if (DEBUG_CHANGE_REASON) console.log("--- BLOCK #3 CONDITION FAILED for explicit Time of Day return ---");
 }
 
 // REMOVE ANY DUPLICATE IF BLOCK FOR THIS LOGIC.
@@ -2639,7 +2644,7 @@ if (changes.includes('Frequency changed') && changes.includes('Time of day chang
 }
 // --- End of New Rule ---
 
-  console.log('DEBUG: changes array before final formatting:', JSON.stringify(changes));
+  if (DEBUG_CHANGE_REASON) console.log('DEBUG: changes array before final formatting:', JSON.stringify(changes));
 
   // Consolidate: If "Brand/Generic changed" and "Formulation changed" are both present,
   // and the formulation is part of the brand name (e.g. Metoprolol Tartrate vs Lopressor),


### PR DESCRIPTION
## Summary
- add `DEBUG_CHANGE_REASON` flag to control console output
- gate all `console.log` statements in `getChangeReason` behind the flag

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test`