### PR TITLE
Handle INR range in indications

### DIFF
--- a/index.html
+++ b/index.html
@@ -2183,16 +2183,18 @@ function normalizeIndicationText(txt = '') {
 
 function normalizeIndication(txt) {
   if (!txt) return '';
-  return txt.toLowerCase()
+  txt = txt
+    .toLowerCase()
     .replace(/\b(type\s*2\s*)?diabetes\b/g, 'diabetes')
     .replace(/\b(htn|hypertension|high blood pressure)\b/g, 'hypertension')
     .replace(/\bhigh cholesterol\b/g, 'cholesterol')
-    .replace(/\banxious\b/g,           'anxiety')
+    .replace(/\banxious\b/g, 'anxiety')
     .replace(/\bas needed\b/g, 'prn')
-    .replace(/\binr\s*2\.?0?\s*-\s*3\.?0?\b/gi, 'inr 2-3')
-    .replace(/\bfor sleep\b/i, 'sleep')
-    .replace(/\b(no\s+)?taper\b/gi, '')
-    .trim();
+    .replace(/\bfor sleep\b/i, 'sleep');
+
+  txt = txt.replace(/\binr\s*2\.?0?\s*-\s*3\.?0?\b/gi, '').trim();
+  txt = txt.replace(/\b(no\s+)?taper\b/gi, '').trim();
+  return txt;
 }
 
 function normalizeTimeOfDay(t) {

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -447,3 +447,15 @@ addTest('Coumadin brand vs warfarin regimen only', () => {
   const after  = 'Coumadin 3 mg regimen INR 2.0-3.0';
   expect(diff(before, after)).toBe('Brand/Generic changed');
 });
+
+addTest('INR range presence vs absence unchanged', () => {
+  const before = 'Warfarin 2 mg tablet nightly';
+  const after  = 'Warfarin 2 mg tablet nightly INR 2.0-3.0';
+  expect(diff(before, after)).toBe('');
+});
+
+addTest('Taper word presence vs absence unchanged', () => {
+  const before = 'Prednisone 10 mg tablet daily';
+  const after  = 'Prednisone 10 mg tablet daily taper';
+  expect(diff(before, after)).toBe('');
+});


### PR DESCRIPTION
## Summary
- ignore INR range and taper phrases in normalizeIndication
- ensure INR ranges or taper wording don't cause diffs

## Testing
- `npm test`