### PR TITLE
Fix brand token duplication

### DIFF
--- a/index.html
+++ b/index.html
@@ -1734,21 +1734,23 @@ const commonIndicationsPatterns = [
 
     /* 1 .  Convert any brand name that appears anywhere in the text
        (e.g. "symbicort 160/4.5") to its generic. */
-    for (const brand in brandToGenericMap) {
-      const re = new RegExp('\\b' + brand + '\\b', 'gi');
-      n = n.replace(re, match => {
-        brandTok.push(match.toLowerCase());
-        return brandToGenericMap[brand];
-      });
-    }
+      for (const brand in brandToGenericMap) {
+        const re = new RegExp('\\b' + brand + '\\b', 'gi');
+        n = n.replace(re, match => {
+          const token = match.toLowerCase();
+          if (!brandTok.includes(token)) brandTok.push(token);
+          return brandToGenericMap[brand];
+        });
+      }
 
-    for (const syn in brandSynonyms) {
-      const reSyn = new RegExp('\\b' + syn + '\\b', 'gi');
-      n = n.replace(reSyn, match => {
-        brandTok.push(match.toLowerCase());
-        return brandSynonyms[syn];
-      });
-    }
+      for (const syn in brandSynonyms) {
+        const reSyn = new RegExp('\\b' + syn + '\\b', 'gi');
+        n = n.replace(reSyn, match => {
+          const token = match.toLowerCase();
+          if (!brandTok.includes(token)) brandTok.push(token);
+          return brandSynonyms[syn];
+        });
+      }
     // Apply generic synonyms after brand replacements
     for (const syn in genericSynonyms) {
       const reSyn = new RegExp('\\b' + syn + '\\b', 'gi');

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -350,6 +350,26 @@ addTest('Brand token captured in array', () => {
   expect(order.brandTokens).toEqual(['lipitor']);
 });
 
+addTest('Duplicate brand names deduped', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const script = html.split('<script>')[2].split('</script>')[0];
+  const ctx = { console: { log: () => {}, warn: () => {}, error: () => {} }, window: {}, document: { querySelectorAll: () => [], getElementById: () => ({ }), addEventListener: () => {} }, firebase: { initializeApp: () => ({}), functions: () => ({ httpsCallable: () => () => ({}) }) } };
+  vm.createContext(ctx);
+  vm.runInContext(script, ctx);
+  const order = ctx.parseOrder('Lipitor Lipitor 40 mg tablet daily');
+  expect(order.brandTokens).toEqual(['lipitor']);
+});
+
+addTest('Duplicate brand synonyms deduped', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const script = html.split('<script>')[2].split('</script>')[0];
+  const ctx = { console: { log: () => {}, warn: () => {}, error: () => {} }, window: {}, document: { querySelectorAll: () => [], getElementById: () => ({ }), addEventListener: () => {} }, firebase: { initializeApp: () => ({}), functions: () => ({ httpsCallable: () => () => ({}) }) } };
+  vm.createContext(ctx);
+  vm.runInContext(script, ctx);
+  const order = ctx.parseOrder('Coumadin Coumadin 5 mg daily');
+  expect(order.brandTokens).toEqual(['coumadin']);
+});
+
 addTest('Generic name has no brand tokens', () => {
   const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
   const script = html.split('<script>')[2].split('</script>')[0];


### PR DESCRIPTION
## Summary
- avoid duplicate brand tokens when normalizing medication names
- test deduplication for repeated brand names and synonyms

## Testing
- `npm test`