### PR TITLE
Extend normalizeIndication cleaning

### DIFF
--- a/index.html
+++ b/index.html
@@ -2194,8 +2194,11 @@ function normalizeIndication(txt) {
     .replace(/\bas needed\b/g, 'prn')
     .replace(/\bfor sleep\b/i, 'sleep');
 
-  txt = txt.replace(/\binr\s*2\.?0?\s*-\s*3\.?0?\b/gi, '').trim();
-  txt = txt.replace(/\b(no\s+)?taper\b/gi, '').trim();
+  txt = txt
+    .replace(/\banticoag(ulation)? clinic\b/gi, '')
+    .replace(/\binr\s*\d(\.\d)?\s*-\s*\d(\.\d)?\b/gi, '')
+    .replace(/\b(no\s+)?taper\b/gi, '')
+    .trim();
   return txt;
 }
 

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -491,3 +491,15 @@ addTest('Taper word presence vs absence unchanged', () => {
   const after  = 'Prednisone 10 mg tablet daily taper';
   expect(diff(before, after)).toBe('');
 });
+
+addTest('Anticoag clinic phrase ignored', () => {
+  const before = 'Warfarin 2 mg tablet nightly';
+  const after  = 'Warfarin 2 mg tablet nightly anticoag clinic';
+  expect(diff(before, after)).toBe('');
+});
+
+addTest('INR range 2.5-3.5 ignored in diff', () => {
+  const before = 'Warfarin 2 mg tablet nightly';
+  const after  = 'Warfarin 2 mg tablet nightly INR 2.5-3.5';
+  expect(diff(before, after)).toBe('');
+});


### PR DESCRIPTION
## Summary
- expand `normalizeIndication` cleanup patterns
- test anticoag clinic and INR range removal

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script)*