### PR TITLE
Ensure brandTok capped at one token

### DIFF
--- a/index.html
+++ b/index.html
@@ -1738,7 +1738,9 @@ const commonIndicationsPatterns = [
         const re = new RegExp('\\b' + brand + '\\b', 'gi');
         n = n.replace(re, match => {
           const token = match.toLowerCase();
-          if (!brandTok.includes(token)) brandTok.push(token);
+          if (brandTok.length === 0 && !brandTok.includes(token)) {
+            brandTok.push(token);
+          }
           return brandToGenericMap[brand];
         });
       }
@@ -1747,7 +1749,9 @@ const commonIndicationsPatterns = [
         const reSyn = new RegExp('\\b' + syn + '\\b', 'gi');
         n = n.replace(reSyn, match => {
           const token = match.toLowerCase();
-          if (!brandTok.includes(token)) brandTok.push(token);
+          if (brandTok.length === 0 && !brandTok.includes(token)) {
+            brandTok.push(token);
+          }
           return brandSynonyms[syn];
         });
       }

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -370,6 +370,16 @@ addTest('Duplicate brand synonyms deduped', () => {
   expect(order.brandTokens).toEqual(['coumadin']);
 });
 
+addTest('Mixed brand/generic only first captured', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const script = html.split('<script>')[2].split('</script>')[0];
+  const ctx = { console: { log: () => {}, warn: () => {}, error: () => {} }, window: {}, document: { querySelectorAll: () => [], getElementById: () => ({ }), addEventListener: () => {} }, firebase: { initializeApp: () => ({}), functions: () => ({ httpsCallable: () => () => ({}) }) } };
+  vm.createContext(ctx);
+  vm.runInContext(script, ctx);
+  const order = ctx.parseOrder('Coumadin (generic) Coumadin 5 mg');
+  expect(order.brandTokens).toEqual(['coumadin']);
+});
+
 addTest('Generic name has no brand tokens', () => {
   const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
   const script = html.split('<script>')[2].split('</script>')[0];


### PR DESCRIPTION
## Summary
- stop accumulating more than one brand token in `normalizeMedicationName`
- test deduplication when brand name and generic repeat

## Testing
- `npm test`