### PR TITLE
Fix INR regex in normalizeIndication and add test

### DIFF
--- a/index.html
+++ b/index.html
@@ -2190,7 +2190,7 @@ function normalizeIndication(txt) {
 
   txt = txt
     .replace(/\banticoag(ulation)? clinic\b/gi, '')
-    .replace(/\binr\s*\d(\.\d)?\s*-\s*\d(\.\d)?\b/gi, '')
+    .replace(/\binr\s*\d+(?:\.\d+)?\s*-\s*\d+(?:\.\d+)?\b/gi, '')
     .replace(/\b(no\s+)?taper\b/gi, '')
     .trim();
   return txt;

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -517,6 +517,12 @@ addTest('INR range 2.5-3.5 ignored in diff', () => {
   expect(diff(before, after)).toBe('');
 });
 
+addTest('INR decimal zeros ignored in diff', () => {
+  const before = 'Warfarin 2 mg tablet nightly';
+  const after  = 'Warfarin 2 mg tablet nightly INR 2.0-3.00';
+  expect(diff(before, after)).toBe('');
+});
+
 addTest('Vancomycin gram vs g no change', () => {
   expect(diff('Vancomycin 1 gram q12h', 'Vancomycin 1 g q12h')).toBe('');
 });


### PR DESCRIPTION
## Summary
- broaden `normalizeIndication` INR regex to match multi-digit ranges and decimals
- test ignoring of decimal zero INR range

## Testing
- `npm test`