### PR TITLE
Fix vancomycin trough comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -2179,6 +2179,10 @@ function normalizeIndicationText(txt = '') {
 
 function normalizeIndication(txt) {
   if (!txt) return '';
+  // Strip trailing trough comments like "- target trough 15-20 mcg/mL" early
+  // so dose numbers inside the note don't get parsed as part of the order.
+  txt = txt.replace(/-\s*(target\s+)?trough.*$/i, '');
+
   txt = txt
     .toLowerCase()
     .replace(/\b(type\s*2\s*)?diabetes\b/g, 'diabetes')
@@ -2685,6 +2689,8 @@ if (changes.includes('Frequency changed') && changes.includes('Time of day chang
   const originalRaw = orderStr;   // keep untouched copy
   orderStr = orderStr.replace(/[\u2010\u2011\u2012\u2013\u2014\u2015\u2212]/g, '-');
   orderStr = normalizeText(orderStr); // Normalizes "qhs" to "at bedtime", etc.
+  // Strip trailing trough comments so numeric targets don't get parsed as doses
+  orderStr = orderStr.replace(/-\s*(target\s+)?trough.*$/i, '').trim();
 
   let order = {
     drug: "",

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -542,3 +542,11 @@ addTest('Prednisone taper vs no taper quantity diff', () => {
   const a = 'Prednisone 20 mg no taper';
   expect(diff(b, a)).toBe('Dose changed, Quantity changed');
 });
+
+addTest('Vancomycin trough comment ignored', () => {
+  const before =
+    'Vancomycin 1 g IV q12h - Trough before 4th dose';
+  const after  =
+    'Vancomycin Hydrochloride 1 gram IV every 12 hours - target trough 15-20 mcg/mL';
+  expect(diff(before, after)).toBe('');
+});


### PR DESCRIPTION
## Summary
- ignore trough/target trough notes when normalizing indications
- drop trailing trough comments before parsing orders
- cover vancomycin trough comment with a regression test

## Testing
- `npm test`