### PR TITLE
Improve indication comparison logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -2195,18 +2195,14 @@ function normalizeIndication(txt) {
   txt = txt
     .replace(/\banticoag(ulation)? clinic\b/gi, '')
     .replace(/\binr\s*\d+(?:\.\d+)?\s*-\s*\d+(?:\.\d+)?\b/gi, '')
-    .replace(/\b(no\s+)?taper\b/gi, '')
-    .replace(/\bpo\b/gi, '')
-    .replace(/\bby mouth\b/gi, '')
-    .replace(/\borally\b/gi, '')
-    .replace(/\bdaily\b/gi, '')
-    .replace(/\bin evening\b/gi, '')
-    .replace(/\bevening\b/gi, '')
-    .replace(/\bmorning\b/gi, '')
-    .replace(/\bat bedtime\b/gi, '')
-    .replace(/\bqhs\b/gi, '')
+    .replace(/\b(no\s+)?taper\b/gi, '');
+
+  const fillerRE =
+    /\b(?:po|by mouth|orally|tablet?s?|tab|daily|every day|in evening|evening|at bedtime|morning|stop|no taper|taper|for \d+\s*days?)\b/gi;
+  txt = txt
+    .replace(fillerRE, ' ')
+    .replace(/\s+/g, ' ')
     .trim();
-  if (!txt) return '';
   return txt;
 }
 
@@ -2419,7 +2415,7 @@ function getChangeReason(orig, updated) {
     simpleNorm(orig.prnCondition) === simpleNorm(updated.prnCondition);
   const indA = normInd(orig.indication);
   const indB = normInd(updated.indication);
-  const indicationDiff = !(!indA && !indB) && indA !== indB;
+  const indicationDiff = indA && indB && indA !== indB;
   const startDateMatch = same(orig.startDate, updated.startDate);
   const endDateMatch = same(orig.endDate, updated.endDate);
   const qtyMatch = same(orig.qty ?? 1, updated.qty ?? 1); // Default to 1 if null for comparison
@@ -3763,8 +3759,12 @@ function findContraIndications(allOrders) {
   if (a.prn !== b.prn) return false;
 
 // ——— ENSURE PAIN INDICATION MATCHES (NORMALIZED) ——— (Fix 1C)
-if ((a.indication || b.indication) && normalizeIndicationText(a.indication) !== normalizeIndicationText(b.indication)) {
-  return false;
+{
+  const ind1 = normalizeIndicationText(a.indication || '');
+  const ind2 = normalizeIndicationText(b.indication || '');
+  if (ind1 && ind2 && ind1 !== ind2) {
+    return false;
+  }
 }
 // ——————————————————————————————
 
@@ -4477,21 +4477,6 @@ if (!match) {
     match = added.find(a => a.original.toLowerCase().includes(drugName));
     if (match) {
         changeType = getChangeReason(r.parsed, match.parsed);
-
-        // very novice-friendly override for “only indication” cases
-        const origInd = (r.parsed.indication || '').toLowerCase().trim();
-        const newInd  = (match.parsed.indication || '').toLowerCase().trim();
-        const normOrig = normalizeIndicationText(origInd);
-        const normNew  = normalizeIndicationText(newInd);
-        if (
-            normalizeMedicationName(r.parsed.drug).name === normalizeMedicationName(match.parsed.drug).name
-            && r.parsed.dose.value === match.parsed.dose.value
-            && r.parsed.dose.unit  === match.parsed.dose.unit
-            && normOrig !== normNew
-        ) {
-            changeType = 'Indication changed';
-        }
-
         console.log(`   → substring matched "${drugName}" to`, match.original);
     }
 }  // <-- closes the if(!match) block correctly

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -28,7 +28,7 @@ describe('Medication comparison', () => {
     expect(result).toBe('Dose changed, Form changed');
   });
 
-  test('adding nerve pain indication detected', () => {
+  test('adding nerve pain indication ignored when original blank', () => {
     const ctx = loadAppContext();
     const before = 'Gabapentin 300mg capsule - take 1 cap po tid';
     const after = 'Gabapentin 300mg capsule - take 1 cap po tid for nerve pain';
@@ -36,7 +36,7 @@ describe('Medication comparison', () => {
     const p2 = ctx.parseOrder(after);
     expect(p2.indication).toBe('nerve pain');
     const result = ctx.getChangeReason(p1, p2);
-    expect(result).toBe('Indication changed');
+    expect(result).toBe('Unchanged');
   });
 
   test('route change from oral to sublingually detected', () => {
@@ -76,5 +76,21 @@ describe('Medication comparison', () => {
     const after = 'Clonidine 0.1 mg tablet – Take 1 tablet by mouth twice a day';
     const result = ctx.getChangeReason(ctx.parseOrder(before), ctx.parseOrder(after));
     expect(result).toBe('Frequency changed, Route changed, Form changed');
+  });
+
+  test('filler words in indication ignored', () => {
+    const ctx = loadAppContext();
+    const before = 'Prednisone 5 mg tablet - take 1 tablet daily for asthma';
+    const after = 'Prednisone 5 mg tablet - take 1 tablet daily for asthma for 7 days stop';
+    const result = ctx.getChangeReason(ctx.parseOrder(before), ctx.parseOrder(after));
+    expect(result).toBe('Unchanged');
+  });
+
+  test('indication change requires both non-empty', () => {
+    const ctx = loadAppContext();
+    const before = 'Gabapentin 300mg capsule - take 1 cap tid for nerve pain';
+    const after = 'Gabapentin 300mg capsule - take 1 cap tid for seizures';
+    const result = ctx.getChangeReason(ctx.parseOrder(before), ctx.parseOrder(after));
+    expect(result).toBe('Indication changed');
   });
 });


### PR DESCRIPTION
## Summary
- tune normalizeIndication to strip schedule filler words
- treat empty indications as equal when comparing
- remove obsolete substring indication rule
- update equality check for indications
- expand tests for new behavior

## Testing
- `npm test`