### PR TITLE
Add insulin and warfarin brand comparison tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -3543,7 +3543,7 @@ if (orderStr.length > 0) {
 }
 
 // Strip common inhaler device terms that can trail the drug name
-const deviceWords = /\b(respimat|handihaler|actuation|flexpen|pen|diskus)\b/i;
+const deviceWords = /\b(respimat|handihaler|actuation|flexpen|kwikpen|solostar|pen|diskus)\b/i;
 orderStr = orderStr.replace(deviceWords, '').replace(/\/\s*$/, '').trim();
 finalDrugName = finalDrugName.replace(deviceWords, '').replace(/\/\s*$/, '').trim();
 

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -570,3 +570,15 @@ addTest('Prednisone taper vs 5-day course indication equal', () => {
     'Prednisone 20 mg daily x5 days for COPD'))
     .toBe('Dose changed, Quantity changed');
 });
+
+addTest('Humalog vs insulin lispro brand flag', () => {
+  expect(diff('Humalog KwikPen 10 u ac',
+              'Insulin Lispro KwikPen 10 u ac'))
+    .toBe('Brand/Generic changed');
+});
+
+addTest('Warfarin vs Coumadin brand flag only', () => {
+  expect(diff('Warfarin 3 mg daily evening',
+              'Coumadin 3 mg daily evening'))
+    .toBe('Brand/Generic changed');
+});


### PR DESCRIPTION
## Summary
- flag KwikPen device word when normalizing medication name
- add tests for Humalog vs insulin lispro and warfarin vs Coumadin

## Testing
- `npm test`