### PR TITLE
Add trough monitoring diff test

### DIFF
--- a/index.html
+++ b/index.html
@@ -2179,13 +2179,8 @@ function normalizeIndicationText(txt = '') {
 
 function normalizeIndication(txt) {
   if (!txt) return '';
-  // Strip trailing trough comments like "- target trough 15-20 mcg/mL" early
-  // so dose numbers inside the note don't get parsed as part of the order.
-  txt = txt.replace(/-\s*(target\s+)?trough.*$/i, '');
 
   txt = txt
-    .replace(/trough\s+before\s+\d+(st|nd|rd|th)\s+dose/gi, '')
-    .replace(/target\s+trough\s+\d+\s*-\s*\d+\s*mcg\/?ml/gi, '')
     .toLowerCase()
     .replace(/\b(type\s*2\s*)?diabetes\b/g, 'diabetes')
     .replace(/\b(htn|hypertension|high blood pressure)\b/g, 'hypertension')
@@ -2697,8 +2692,12 @@ if (changes.includes('Frequency changed') && changes.includes('Time of day chang
   const originalRaw = orderStr;   // keep untouched copy
   orderStr = orderStr.replace(/[\u2010\u2011\u2012\u2013\u2014\u2015\u2212]/g, '-');
   orderStr = normalizeText(orderStr); // Normalizes "qhs" to "at bedtime", etc.
+  // Capture trailing trough monitoring notes before removing them
+  let troughNote = null;
+  const troughMatch = orderStr.match(/-\s*((?:target\s+)?trough.*)$/i);
+  if (troughMatch) troughNote = troughMatch[1].trim();
   // Strip trailing trough comments so numeric targets don't get parsed as doses
-  orderStr = orderStr.replace(/-\s*(target\s+)?trough.*$/i, '').trim();
+  orderStr = orderStr.replace(/-\s*(?:target\s+)?trough.*$/i, '').trim();
 
   let order = {
     drug: "",
@@ -3631,6 +3630,7 @@ if (!order.route && oralFormsForPo.includes(order.form)) {
 
   order.frequency  = normalizeFrequency(order.frequency);
   order.timeOfDay  = normalizeTimeOfDay(order.timeOfDay);
+  if (!order.indication && troughNote) order.indication = troughNote;
   order.indication = normalizeIndication(order.indication);
   order.formulation = canonFormulation(order.formulation);
 

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -543,12 +543,11 @@ addTest('Prednisone taper vs no taper quantity diff', () => {
   expect(diff(b, a)).toBe('Dose changed, Quantity changed');
 });
 
-addTest('Vancomycin trough comment ignored', () => {
-  const before =
-    'Vancomycin 1 g IV q12h - Trough before 4th dose';
-  const after  =
-    'Vancomycin Hydrochloride 1 gram IV every 12 hours - target trough 15-20 mcg/mL';
-  expect(diff(before, after)).toBe('');
+addTest('Vancomycin monitoring wording', () => {
+  expect(diff(
+    'Vancomycin 1 g q12h – trough before 4th dose',
+    'Vancomycin hydrochloride 1 g q12h – target trough 15-20 mcg/mL'))
+    .toBe('Indication changed');
 });
 addTest('Warfarin brand with INR & schedule words – indication equal', () => {
   const a = 'Warfarin 3mg MWF 3mg TTSu 1.5mg INR 2-3 PO evening';


### PR DESCRIPTION
## Summary
- treat trailing vancomycin trough notes as indications
- update test runner for new Vancomycin monitoring wording check

## Testing
- `npm test`