### PR TITLE
Fix dose change suppression

### DIFF
--- a/index.html
+++ b/index.html
@@ -2347,15 +2347,12 @@ function getChangeReason(orig, updated) {
   }
 
   const doseValueMatch = valuesEqual(orig.dose?.value, updated.dose?.value);
+  // Compare total dose, defaulting quantity to 1 when missing
   const qty1 = orig.qty == null ? 1 : orig.qty;
   const qty2 = updated.qty == null ? 1 : updated.qty;
   const tot1 = (orig.dose?.value ?? 0) * qty1;
   const tot2 = (updated.dose?.value ?? 0) * qty2;
   const doseTotalMatch = tot1 === tot2;
-  // If only freq differs and dose totals identical, suppress "Dose changed"
-  if (changes.includes('Dose changed') && doseTotalMatch) {
-    changes = changes.filter(c => c !== 'Dose changed');
-  }
   const doseUnitMatch =
     canonUnit(orig.rawUnit || orig.dose?.unit) ===
     canonUnit(updated.rawUnit || updated.dose?.unit);
@@ -2522,6 +2519,11 @@ function getChangeReason(orig, updated) {
   // the strength per spray/tablet is identical but the quantity varies.
 if (!doseUnitMatch || !doseValueMatch || (!doseTotalMatch && qtyMatch)) {
   add('Dose changed');
+}
+// If totals are equal (quantity defaults to 1) and we added the dose flag, it
+// likely came from a frequency-only change, so remove it.
+if (doseTotalMatch && changes.includes('Dose changed')) {
+  changes = changes.filter(c => c !== 'Dose changed');
 }
 // Quantity differences are reflected in the dose when totals differ, but still
 // list them separately to highlight dispensing changes.

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -295,21 +295,21 @@ addTest('Klor-Con brand only', () => {
 addTest('Tylenol brand flag', () => {
   const b = 'Tylenol 500 mg 2 tabs PO q6h prn pain';
   const a = 'Acetaminophen 1000 mg tab PO every 6 hours as needed for pain';
-  expect(diff(b, a)).toBe('Dose changed, Quantity changed, Brand/Generic changed');
+  expect(diff(b, a)).toBe('Quantity changed, Brand/Generic changed');
 });
 
 addTest('Implicit tablet form same', () => {
   const before = 'Tylenol 500 mg 2 tabs PO q6h prn pain';
   const after  = 'Acetaminophen 1000 mg PO every 6 hours as needed for pain';
   expect(diff(before, after))
-    .toBe('Dose changed, Quantity changed, Brand/Generic changed');
+    .toBe('Quantity changed, Brand/Generic changed');
 });
 
 addTest('Tabs vs no form equal', () => {
   const before = 'Tylenol 500 mg 2 tabs po q6h prn pain';
   const after  = 'Acetaminophen 1000 mg po every 6 h as needed for pain';
   expect(diff(before, after))
-    .toBe('Dose changed, Quantity changed, Brand/Generic changed');
+    .toBe('Quantity changed, Brand/Generic changed');
 });
 
 addTest('Metoprolol XL vs ER unchanged', () => {


### PR DESCRIPTION
## Summary
- ensure dose totals account for default quantity when matching
- remove `Dose changed` after it's added if totals match
- adjust tests for new behavior

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test`