### PR TITLE
Add Administration change detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -2597,6 +2597,12 @@ if (!routeMatch && (norm(orig.route) || norm(updated.route))) { // Only if route
      add('Route changed');
 }
 
+// --- Administration Change ---
+if (orig.administration && updated.administration &&
+    orig.administration !== updated.administration) {
+    add('Administration changed');
+}
+
 // --- PRN logic ---
 if (orig.prn !== updated.prn) {
   changes.push('PRN changed');
@@ -2726,7 +2732,7 @@ if (changes.includes('Frequency changed') && changes.includes('Time of day chang
   if (changes.length === 1) return changes[0];
   if (changes.length <= 4) { // List up to 4 specific changes
       // Prioritize more significant changes if too many minor ones
-      const priorityOrder = ["Dose changed", "Frequency changed", "Formulation changed", "Quantity changed", "Brand/Generic changed", "Route changed", "Form changed", "PRN changed", "Indication changed", "Date changed", "End Date changed", "Time of day changed"];
+      const priorityOrder = ["Dose changed", "Frequency changed", "Formulation changed", "Quantity changed", "Brand/Generic changed", "Route changed", "Administration changed", "Form changed", "PRN changed", "Indication changed", "Date changed", "End Date changed", "Time of day changed"];
       changes.sort((a, b) => {
           let idxA = priorityOrder.indexOf(a);
           let idxB = priorityOrder.indexOf(b);

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -105,4 +105,16 @@ describe('Medication comparison', () => {
     const order = ctx.parseOrder('Aspirin 1/2 tab daily');
     expect(order.qty).toBe(0.5);
   });
+
+  test('administration difference flagged', () => {
+    const ctx = loadAppContext();
+    const before = 'Metformin 500 mg tablet - take 1 tablet with food daily';
+    const after = 'Metformin 500 mg tablet - take 1 tablet between meals daily';
+    const p1 = ctx.parseOrder(before);
+    const p2 = ctx.parseOrder(after);
+    expect(p1.administration).toBe('with food');
+    expect(p2.administration).toBe('between meals');
+    const result = ctx.getChangeReason(p1, p2);
+    expect(result).toBe('Frequency changed, Administration changed');
+  });
 });

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -95,7 +95,7 @@ require('./medDiff.test');
 addTest('Metformin evening vs nightly time change', () => {
   const before = 'Metformin hydrochloride 1000mg ER - take one tablet by mouth every evening with supper';
   const after = 'Metformin ER 1000mg - take 1 tab PO nightly with food';
-  expect(diff(before, after)).toBe('Time of day changed');
+  expect(diff(before, after)).toBe('Administration changed, Time of day changed');
 });
 
 addTest('Vitamin D brand/generic without formulation change', () => {


### PR DESCRIPTION
## Summary
- detect when administration instructions differ in `getChangeReason`
- sort administration changes using the priority list
- adjust expected results and add a new test case

## Testing
- `npm test`