### PR TITLE
Add brand/time and numeric frequency tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -3459,7 +3459,7 @@ if (!order.frequency) { // <<<< ADD THIS OPENING 'if' and its brace
         } else {
           const freqMapping = { /* ... your existing map ... */
               "once daily": "daily", "once a day": "daily", "1 times daily": "daily", "daily": "daily", "od": "daily", "qd": "daily",
-              "twice daily": "twice daily", "2 times daily": "twice daily", "bid": "twice daily", "twice a day": "twice daily",
+              "twice daily": "twice daily", "2 times daily": "twice daily", "2 times a day": "twice daily", "bid": "twice daily", "twice a day": "twice daily",
               "three times daily": "three times daily", "3 times daily": "three times daily", "tid": "three times daily", "tidac": "three times daily", "before meals": "three times daily", "with meals": "three times daily", "before breakfast lunch dinner": "three times daily",
               "four times daily": "four times daily", "4 times daily": "four times daily", "qid": "four times daily",
               "every other day": "every other day", "qod": "every other day",

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -655,3 +655,15 @@ addTest('Iron admin change flagged', () => {
   const after = 'Iron sulfate 325 mg po q12h between meals';
   expect(diff(before, after)).toBe('Frequency changed, Administration changed');
 });
+
+addTest('Warfarin tabs regimen diff only brand/time', () => {
+  const before = 'Warfarin 3 mg tabs: 1 tab M/W/F 3 mg; Tu/Th/Sa/Su 1.5 mg evening';
+  const after = 'Coumadin 3 mg tabs: 1 tab M/W/F 3 mg; Tu/Th/Sa/Su 1.5 mg nightly';
+  expect(diff(before, after)).toBe('Brand/Generic changed, Time of day changed');
+});
+
+addTest('Numeric frequency two times a day flagged', () => {
+  const before = 'Metformin 500 mg tablet - take 1 tab 2 times a day';
+  const after = 'Metformin 500 mg tablet - take 1 tab daily';
+  expect(diff(before, after)).toBe('Frequency changed');
+});


### PR DESCRIPTION
## Summary
- update frequency map to recognize `2 times a day`
- add tests for warfarin vs coumadin schedule wording
- add test verifying numeric frequency detection

## Testing
- `npm test`
