### PR TITLE
Add PRN indication normalization tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -2165,6 +2165,14 @@ function normalizeIndication(txt) {
     .replace(fillerRE, ' ')
     .replace(/\s+/g, ' ')
     .trim();
+  const synonyms = {
+    'shortness of breath': 'breathing difficulty',
+    sob: 'breathing difficulty',
+    wheezing: 'breathing difficulty',
+    'nerve pain': 'neuropathy',
+    neuropathy: 'neuropathy'
+  };
+  if (synonyms[txt]) txt = synonyms[txt];
   return txt;
 }
 
@@ -3079,6 +3087,9 @@ orderStr = orderStr.replace(/\bmay\s+increase\s+to.*$/i, '').trim();
       orderStr = orderStr.replace(sobMatch[0], '').trim();
       // console.log(`DEBUG parseOrder Step 4c (SOB Indication): order.indication="${order.indication}", orderStr="${orderStr}"`);
     }
+  }
+  if (!order.indication && order.prnCondition) {
+    order.indication = order.prnCondition;
   }
   // At this point, for your new order, order.indication should ideally be "moderate pain"
   // and orderStr should be "atorvastatin 40 mg tablet po" (or similar for other drugs)

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -34,7 +34,7 @@ describe('Medication comparison', () => {
     const after = 'Gabapentin 300mg capsule - take 1 cap po tid for nerve pain';
     const p1 = ctx.parseOrder(before);
     const p2 = ctx.parseOrder(after);
-    expect(p2.indication).toBe('nerve pain');
+    expect(p2.indication).toBe('neuropathy');
     const result = ctx.getChangeReason(p1, p2);
     expect(result).toBe('Unchanged');
   });
@@ -119,6 +119,18 @@ describe('Medication comparison', () => {
     const ctx = loadAppContext();
     const order = ctx.parseOrder('Aspirin 1/2 tab daily');
     expect(order.qty).toBe(0.5);
+  });
+
+  test('prn shortness of breath sets breathing difficulty indication', () => {
+    const ctx = loadAppContext();
+    const order = ctx.parseOrder('Albuterol \u2013 2 puffs PRN shortness of breath');
+    expect(order.indication).toBe('breathing difficulty');
+  });
+
+  test('for neuropathy normalized to neuropathy', () => {
+    const ctx = loadAppContext();
+    const order = ctx.parseOrder('Gabapentin 300 mg \u2013 take 1 cap tid for neuropathy');
+    expect(order.indication).toBe('neuropathy');
   });
 
   test('administration difference flagged', () => {


### PR DESCRIPTION
## Summary
- normalize shortness of breath to breathing difficulty in `normalizeIndication`
- default `indication` to prn condition when missing
- update and expand medication diff tests

## Testing
- `npm test`