### PR TITLE
Fix ER handling logic in change detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -2492,8 +2492,13 @@ function getChangeReason(orig, updated) {
     // remove the tag if it was added earlier
     changes = changes.filter(c => c !== 'Formulation changed');
   }
-  const stripER = f => (f || '').replace(/\ber\b/gi, '').trim();
-  if (!formulationMatch && stripER(orig.formulation) === stripER(updated.formulation)) {
+  const hasCanonER = f => /\ber\b/i.test(canonFormulation(f));
+  const stripER = f => canonFormulation(f).replace(/\ber\b/gi, '').trim();
+  if (
+    !formulationMatch &&
+    stripER(orig.formulation) === stripER(updated.formulation) &&
+    hasCanonER(orig.formulation) === hasCanonER(updated.formulation)
+  ) {
     formulationMatch = true;
     changes = changes.filter(c => c !== 'Formulation changed');
   }

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -217,6 +217,12 @@ addTest('Metformin HCl ER vs Metformin ER unchanged', () => {
   expect(diff(b, a)).toBe('Time of day changed');
 });
 
+addTest('Metformin ER vs IR keeps formulation flag only', () => {
+  const before = 'Metformin 500mg tab – 2 PO BID';
+  const after  = 'Metformin ER 500mg – 2 PO BID';
+  expect(diff(before, after)).toBe('Formulation changed');
+});
+
 addTest('Fluticasone propionate omission not formulation', () => {
   const before = 'Fluticasone Propionate nasal spray 50 mcg – 2 sprays each nostril daily';
   const after  = 'Fluticasone nasal spray 50 mcg – 1 spray each nostril qd';


### PR DESCRIPTION
## Summary
- prevent false formulation matches when only one medication includes ER
- test that Metformin ER vs IR keeps the formulation change flag

## Testing
- `npm test`