### PR TITLE
Add inhaler brand route normalization test

### DIFF
--- a/index.html
+++ b/index.html
@@ -2523,6 +2523,12 @@ function getChangeReason(orig, updated) {
     if ((r1 === 'po' && !r2) || (r2 === 'po' && !r1)) {
       routeMatch = true;
     }
+    // Treat inhaler brand swaps with 'by mouth' as inhalation
+    if (!routeMatch && inhaled(orig) && inhaled(updated)) {
+      if ((r1 === 'po' && r2 === 'inhalation') || (r2 === 'po' && r1 === 'inhalation')) {
+        routeMatch = true;
+      }
+    }
   }
   const prnMatch = same(orig.prn, updated.prn);
   const ind1 = normalizeIndication(orig.indication);

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -168,4 +168,14 @@ describe('Medication comparison', () => {
     const result = ctx.getChangeReason(ctx.parseOrder(before), ctx.parseOrder(after));
     expect(result).toBe('Frequency changed, Time of day changed');
   });
+
+  test('Inhaler brand swap does not trigger Route flag', () => {
+    const ctx = loadAppContext();
+    const o = ctx.parseOrder('Albuterol HFA inhaler 2 puffs by mouth q4h PRN');
+    const n = ctx.parseOrder('ProAir Respiclick 2 puffs inhalation q6h PRN');
+    const result = ctx.getChangeReason(o, n);
+    if (result.includes('Route changed')) {
+      throw new Error('Route flag set for inhaler brand swap: ' + result);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add regression test for inhaler brand swap
- normalize route comparison for inhaler brand swaps

## Testing
- `npm test`