### PR TITLE
Handle Coumadin frequency parity

### DIFF
--- a/index.html
+++ b/index.html
@@ -2802,6 +2802,13 @@ else {
       changes = changes.filter(c => c !== 'Dose changed');
     }
   }
+  if (
+    changes.includes('Frequency changed') &&
+    coumBrand &&
+    freqSameNum
+  ) {
+    changes = changes.filter(c => c !== 'Frequency changed');
+  }
 
   // collapse trivial TOD/freq double-hit
   if (

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -769,7 +769,7 @@ addTest('Coumadin brand & time only', () => {
   expect(diff(
     'Warfarin 3 mg 1 tab M/W/F; \u00bd tab Tu/Th/Sa/Su',
     'Coumadin 3 mg 1 tab M/W/F; \u00bd tab Tu/Th/Sa/Su evening'
-  )).toBe('Frequency changed, Brand/Generic changed, Time of day changed');
+  )).toBe('Brand/Generic changed, Time of day changed');
 });
 
 /* “2 times a day” numeric frequency */
@@ -790,4 +790,10 @@ addTest('BID equals two times a day', () => {
   const b = 'Metformin 500 mg tablet po BID';
   const a = 'Metformin 500 mg tablet po two times a day';
   expect(diff(b, a)).toBe('');
+});
+
+addTest('Coumadin brand swap with numeric freq unchanged', () => {
+  const before = 'Warfarin 3 mg tablet po BID';
+  const after = 'Coumadin 3 mg tablet po twice daily';
+  expect(diff(before, after)).toBe('Brand/Generic changed');
 });


### PR DESCRIPTION
## Summary
- suppress `Frequency changed` when Warfarin <-> Coumadin swap keeps the same numeric frequency
- adjust test expectation for Coumadin weekly regimen
- add test verifying frequency parity between BID and numeric "twice daily" during Coumadin switch

## Testing
- `npm test`