### PR TITLE
Add warfarin sodium formulation unit test

### DIFF
--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -802,3 +802,22 @@ addTest('Refills count change flagged', () => {
   const after  = 'Amoxicillin 500 mg capsule - take 1 cap tid 3 refills';
   expect(diff(before, after)).toBe('Refills changed');
 });
+
+addTest('Warfarin sodium vs warfarin direct comparison', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const script = html.split('<script>')[2].split('</script>')[0];
+  const ctx = {
+    console: { log: () => {}, warn: () => {}, error: () => {} },
+    window: {},
+    document: { querySelectorAll: () => [], getElementById: () => ({}), addEventListener: () => {} },
+    firebase: { initializeApp: () => ({}), functions: () => ({ httpsCallable: () => () => ({}) }) }
+  };
+  vm.createContext(ctx);
+  vm.runInContext(script, ctx);
+  const before = 'Warfarin sodium 5 mg tablet po evening';
+  const after = 'Warfarin 5 mg tablet po qpm';
+  const reason = ctx.getChangeReason(ctx.parseOrder(before), ctx.parseOrder(after));
+  if (reason.includes('Formulation changed')) {
+    throw new Error('Unexpected formulation flag: ' + reason);
+  }
+});


### PR DESCRIPTION
## Summary
- expand runTests.js with a direct parseOrder/getChangeReason check
- ensure `Formulation changed` is not erroneously triggered when comparing warfarin sodium vs warfarin

## Testing
- `npm test`