### PR TITLE
Update brand/generic change detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -2342,6 +2342,20 @@ function inhaled(parsedOrder) {
     return false;
 }
 
+// === brand lookup (add right above getChangeReason) ===
+const brandMap = {
+  lipitor: 'atorvastatin',
+  proair:  'albuterol',
+  'k-dur': 'potassium chloride',
+  lasix:   'furosemide'
+};
+
+const coreName = n => (n||'')
+  .toLowerCase()
+  .replace(/[^a-z0-9\s]/g,'')         // strip punctuation
+  .replace(/\b(?:tablet|tab|capsule|cap|hfa|inhaler|respiclick|pen)\b/g,'')
+  .trim();
+
 // ——— What changed? ———
 function getChangeReason(orig, updated) {
   const DEBUG_CHANGE_REASON = false;
@@ -2364,6 +2378,14 @@ function getChangeReason(orig, updated) {
 
   let changes = [];
   const add = lbl => { if (!changes.includes(lbl)) changes.push(lbl); };
+
+  const gen1 = coreName(orig.drug);
+  const gen2 = coreName(updated.drug);
+  const b1   = brandMap[gen1] || gen1;
+  const b2   = brandMap[gen2] || gen2;
+  if (b1 === b2 && gen1 !== gen2 && !changes.includes('Brand/Generic changed')) {
+    changes.push('Brand/Generic changed');
+  }
 
   const norm = s => (s || '').toLowerCase().trim().replace(/\s+/g, ' ');
   // --- 2. Frequency: normalise “daily” variants ---


### PR DESCRIPTION
## Summary
- detect brand/generic swaps using a simple brand lookup
- recognize when brand and generic names are equivalent

## Testing
- `npm test`