### PR TITLE
Handle spelled-out quantities

### DIFF
--- a/index.html
+++ b/index.html
@@ -2972,6 +2972,20 @@ return 'Multiple changes'; // For 5 or more
   }
 
   function extractQuantity(str, order) {
+    const word2num = {
+      one: 1,
+      two: 2,
+      three: 3,
+      four: 4,
+      five: 5,
+      six: 6,
+      seven: 7,
+      eight: 8,
+      nine: 9,
+      ten: 10
+    };
+    const wordRegex = new RegExp(`\\b(${Object.keys(word2num).join('|')})\\b`, 'gi');
+    str = str.replace(wordRegex, w => String(word2num[w.toLowerCase()]));
     const qtyRegex = new RegExp(
       `(?:\\b(?:take|give|administer|inhale|inject|apply|use)\\s+)?((?:\\d+\\/\\d+|[\\u00bc-\\u00be]|\\d+(?:\\.\\d+)?))\\s*(${qtyWords.join('|')})(?:s)?\\b`,
       'i'

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -103,6 +103,12 @@ describe('Medication comparison', () => {
     expect(order.qty).toBe(0.5);
   });
 
+  test('spelled-out quantity parsed', () => {
+    const ctx = loadAppContext();
+    const order = ctx.parseOrder('Aspirin one tab daily');
+    expect(order.qty).toBe(1);
+  });
+
   test('prn shortness of breath sets breathing difficulty indication', () => {
     const ctx = loadAppContext();
     const order = ctx.parseOrder('Albuterol \u2013 2 puffs PRN shortness of breath');


### PR DESCRIPTION
## Summary
- parse spelled-out numbers like "one" when extracting quantity
- test parsing spelled-out quantity

## Testing
- `npm test`