### PR TITLE
Add coumadin and basaglar to brandMap

### DIFF
--- a/index.html
+++ b/index.html
@@ -2348,7 +2348,9 @@ const brandMap = {
   lipitor: 'atorvastatin',
   proair:  'albuterol',
   'k-dur': 'potassium chloride',
-  lasix:   'furosemide'
+  lasix:   'furosemide',
+  coumadin: 'warfarin',
+  basaglar: 'insulin glargine'
 };
 const benignBrandSet = new Set(['k-dur']);
 


### PR DESCRIPTION
## Summary
- extend `brandMap` with Coumadin and Basaglar brand lookups

## Testing
- `npm test`
