### PR TITLE
Handle q4-6h frequency ranges

### DIFF
--- a/index.html
+++ b/index.html
@@ -2301,6 +2301,13 @@ function freqNumeric(freqStr) {
   const f = normalizeFrequency(freqStr);
   const map = { daily: 1, bid: 2, tid: 3, qid: 4, weekly: 1 / 7,
                  monthly: 1 / 30, 'every other day': 0.5, immediately: 0 };
+  const range = /^q(\d+)-(\d+)h$/i.exec(f);
+  if (range) {
+    const min = Number(range[1]);
+    const max = Number(range[2]);
+    const avg = (min + max) / 2;
+    return 24 / avg;
+  }
   const qh = /^q(\d+)h$/i.exec(f);
   if (qh) return 24 / Number(qh[1]);
   return map[f] != null ? map[f] : null;

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -34,6 +34,11 @@ describe('freqNumeric', () => {
     expect(ctx.normalizeFrequency('every 4 to 6 hours')).toBe('q4-6h');
   });
 
+  test("freqNumeric handles ranges like 'q4-6h'", () => {
+    const ctx = loadAppContext();
+    expect(ctx.freqNumeric('q4-6h')).toBe(24 / 5);
+  });
+
   test('blank frequency treated as once daily', () => {
     const ctx = loadAppContext();
     expect(ctx.freqNumeric('')).toBe(1);


### PR DESCRIPTION
## Summary
- support `q4-6h` style ranges in `freqNumeric`
- test numeric frequency ranges

## Testing
- `npm test`