### PR TITLE
Add brandPairs map and sameDrugCore function

### DIFF
--- a/index.html
+++ b/index.html
@@ -2376,10 +2376,20 @@ function inhaled(parsedOrder) {
 // === brand lookup (add right above getChangeReason) ===
 const brandMap = {
   lipitor: 'atorvastatin',
-  proair:  'albuterol',
+  proair: 'albuterol',
   'k-dur': 'potassium chloride',
-  lasix:   'furosemide',
+  lasix: 'furosemide',
   coumadin: 'warfarin',
+  basaglar: 'insulin glargine'
+};
+
+// One-to-one brand/generic pairs used for quick same-drug checks
+const brandPairs = {
+  lasix: 'furosemide',
+  coumadin: 'warfarin',
+  lipitor: 'atorvastatin',
+  proair: 'albuterol',
+  'k-dur': 'potassium chloride',
   basaglar: 'insulin glargine'
 };
 const benignBrandSet = new Set(['k-dur']);
@@ -2389,6 +2399,16 @@ const coreName = n => (n||'')
   .replace(/[^a-z0-9\s]/g,'')         // strip punctuation
   .replace(/\b(?:tablet|tab|capsule|cap|hfa|inhaler|respiclick|pen)\b/g,'')
   .trim();
+
+// Compare two raw drug strings using brandPairs and normalized core names
+function sameDrugCore(a, b) {
+  const x = coreName(a);
+  const y = coreName(b);
+  if (x === y) return true;
+  if (brandPairs[x] && brandPairs[x] === y) return true;
+  if (brandPairs[y] && brandPairs[y] === x) return true;
+  return false;
+}
 
 // ——— What changed? ———
 function getChangeReason(orig, updated) {
@@ -2424,9 +2444,11 @@ function getChangeReason(orig, updated) {
 
   const gen1 = coreName(orig.drug);
   const gen2 = coreName(updated.drug);
-  const b1   = brandMap[gen1] || gen1;
-  const b2   = brandMap[gen2] || gen2;
-  if (b1 === b2 && gen1 !== gen2 && !changes.includes('Brand/Generic changed')) {
+  if (
+    sameDrugCore(orig.drug, updated.drug) &&
+    gen1 !== gen2 &&
+    !changes.includes('Brand/Generic changed')
+  ) {
     changes.push('Brand/Generic changed');
   }
 
@@ -4857,7 +4879,7 @@ if (!match) {
 
         // 6) Same-drug match
         const sameDrug = added.find(a =>
-            normalizeMedicationName(a.parsed.drug).name === normalizeMedicationName(r.parsed.drug).name
+            sameDrugCore(a.parsed.drug, r.parsed.drug)
         );
         if (sameDrug) {
             const reason = getChangeReason(r.parsed, sameDrug.parsed);

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -76,3 +76,10 @@ describe('canonFormulation comparisons', () => {
     expect(ctx.getChangeReason(before, after)).toBe('Unchanged');
   });
 });
+
+describe('sameDrugCore', () => {
+  test('Lasix vs furosemide treated as same', () => {
+    const ctx = loadAppContext();
+    expect(ctx.sameDrugCore('Lasix', 'furosemide')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add brandPairs brand↔generic map
- compare drugs with new sameDrugCore helper
- leverage sameDrugCore when detecting brand/generic swaps
- test Lasix vs. furosemide sameDrugCore behavior

## Testing
- `npm test`