### PR TITLE
Improve frequency parsing of spelled-out numbers

### DIFF
--- a/index.html
+++ b/index.html
@@ -2276,6 +2276,10 @@ function getFrequencyMap() {
 function normalizeFrequency(str) {
   if (!str) return '';
   str = str.toLowerCase().trim();
+  // replace numeric words with digits so "three times" => "3 times"
+  str = str.replace(/\b(one|two|three|four|five|six|seven|eight|nine|ten)\b/g,
+    w => String(numericWord(w))
+  );
   const freqMap = getFrequencyMap();
   const sorted = Object.keys(freqMap).sort((a, b) => b.length - a.length);
   for (const key of sorted) {
@@ -2310,14 +2314,28 @@ function freqNumeric(freqStr) {
   }
   const qh = /^q(\d+)h$/i.exec(f);
   if (qh) return 24 / Number(qh[1]);
+  const times = /(\d+)\s*times?\s*(?:a|per)?\s*day\b/.exec(f);
+  if (times) return Number(times[1]);
   return map[f] != null ? map[f] : null;
 }
 
 /* ---------- simple word→number helper (one-ten) ---------- */
-const numericWord = w => ({
-  one:1,two:2,three:3,four:4,five:5,
-  six:6,seven:7,eight:8,nine:9,ten:10
-}[w.toLowerCase()] ?? null);
+function numericWord(w) {
+  return (
+    {
+      one: 1,
+      two: 2,
+      three: 3,
+      four: 4,
+      five: 5,
+      six: 6,
+      seven: 7,
+      eight: 8,
+      nine: 9,
+      ten: 10
+    }[w.toLowerCase()] ?? null
+  );
+}
 
 // ---------- QUANTITY PARSER ----------
 function parseQuantity(str){

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -14,6 +14,16 @@ describe('freqNumeric', () => {
     expect(ctx.freqNumeric('2 times a day')).toBe(2);
   });
 
+  test('"three times a day" numeric', () => {
+    const ctx = loadAppContext();
+    expect(ctx.freqNumeric('three times a day')).toBe(3);
+  });
+
+  test('"five times a day" numeric', () => {
+    const ctx = loadAppContext();
+    expect(ctx.freqNumeric('five times a day')).toBe(5);
+  });
+
   test("'three times a day' normalizes to tid", () => {
     const ctx = loadAppContext();
     expect(ctx.normalizeFrequency('three times a day')).toBe('tid');


### PR DESCRIPTION
## Summary
- convert numeric words to digits in `normalizeFrequency`
- parse generic `N times a day` phrases
- expose numeric word helper earlier
- extend `freqNumeric` to handle numeric phrases
- add tests for spelled-out frequencies

## Testing
- `npm test`