### PR TITLE
Add parseQuantity tests and support fractions

### DIFF
--- a/index.html
+++ b/index.html
@@ -2344,11 +2344,13 @@ function numericWord(w) {
 
 // ---------- QUANTITY PARSER ----------
 function parseQuantity(str){
-  // matches “2 tabs”, “two tablets”, etc.
-  const m=str.match(/(\d+|\w+)\s*(tabs?|caps?|tablets?|capsules?)/i);
+  // matches "2 tabs", "one tablet", "½ tab", etc.
+  const m = str.match(/(\d+\/\d+|[\u00bc-\u00be]|\d+(?:\.\d+)?|\w+)\s*(tabs?|caps?|tablets?|capsules?)/i);
   if(!m) return null;
-  const raw=m[1];
-  return /^\d+$/.test(raw)?Number(raw):numericWord(raw)||null;
+  const raw = m[1];
+  const num = fractionToDecimal(raw);
+  if(!Number.isNaN(num)) return num;
+  return numericWord(raw) ?? null;
 }
 
 function quantitiesMatch(o1,o2){

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -93,3 +93,20 @@ describe('sameDrugCore', () => {
     expect(ctx.sameDrugCore('Lasix', 'furosemide')).toBe(true);
   });
 });
+
+describe('parseQuantity', () => {
+  test('"2 tabs" parses to 2', () => {
+    const ctx = loadAppContext();
+    expect(ctx.parseQuantity('2 tabs')).toBe(2);
+  });
+
+  test('"one tablet" parses to 1', () => {
+    const ctx = loadAppContext();
+    expect(ctx.parseQuantity('one tablet')).toBe(1);
+  });
+
+  test('"½ tab" parses to 0.5', () => {
+    const ctx = loadAppContext();
+    expect(ctx.parseQuantity('\u00bd tab')).toBe(0.5);
+  });
+});


### PR DESCRIPTION
## Summary
- update `parseQuantity` helper to handle fractions like `½`
- add Jest-style tests for `parseQuantity`

## Testing
- `npm test`