### PR TITLE
Add insulin brand pairs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2415,7 +2415,9 @@ const brandPairs = {
   lipitor: 'atorvastatin',
   proair: 'albuterol',
   'k-dur': 'potassium chloride',
-  basaglar: 'insulin glargine'
+  basaglar: 'insulin glargine',
+  humalog: 'insulin lispro',
+  novolog: 'insulin aspart'
 };
 const benignBrandSet = new Set(['k-dur']);
 


### PR DESCRIPTION
## Summary
- extend brandPairs list in `index.html` to support Humalog and Novolog

## Testing
- `npm test`
- `npm run lint`