### PR TITLE
Add tylenol and KDur brand mappings

### DIFF
--- a/index.html
+++ b/index.html
@@ -2437,9 +2437,12 @@ const brandPairs = {
   lipitor: 'atorvastatin',
   proair: 'albuterol',
   'k dur': 'potassium chloride',
+  'k-dur': 'potassium chloride',
+  kdur: 'potassium chloride',
   basaglar: 'insulin glargine',
   humalog: 'insulin lispro',
-  novolog: 'insulin aspart'
+  novolog: 'insulin aspart',
+  tylenol: 'acetaminophen'
 };
 const benignBrandSet = new Set(['k-dur']);
 

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -117,6 +117,16 @@ describe('sameDrugCore', () => {
     const ctx = loadAppContext();
     expect(ctx.sameDrugCore('K-Dur', 'potassium chloride')).toBe(true);
   });
+
+  test('KDur vs potassium chloride treated as same', () => {
+    const ctx = loadAppContext();
+    expect(ctx.sameDrugCore('KDur', 'potassium chloride')).toBe(true);
+  });
+
+  test('Tylenol vs acetaminophen treated as same', () => {
+    const ctx = loadAppContext();
+    expect(ctx.sameDrugCore('Tylenol', 'acetaminophen')).toBe(true);
+  });
 });
 
 describe('parseQuantity', () => {


### PR DESCRIPTION
## Summary
- expand `brandPairs` with additional potassium chloride and Tylenol aliases
- test new brand pairs

## Testing
- `npm test`