### PR TITLE
Add frequency comparison test

### DIFF
--- a/index.html
+++ b/index.html
@@ -2485,7 +2485,9 @@ function getChangeReason(orig, updated) {
       /(?:before|with) meals/.test(f) ||
       /before breakfast lunch dinner/.test(f) ||
       /(?:before|with) meals/.test(rawNorm) ||
-      /before breakfast lunch dinner/.test(rawNorm)
+      /before breakfast lunch dinner/.test(rawNorm) ||
+      /with food/.test(f) ||
+      /with food/.test(rawNorm)
     ) {
       const stripped = rawNorm
         .replace(/(?:before|with) meals/g, '')

--- a/tests/changeReason.test.js
+++ b/tests/changeReason.test.js
@@ -17,6 +17,22 @@ describe('getChangeReason', () => {
     expect(/Frequency changed/.test(result)).toBe(false);
   });
 
+  test('Meals wording normalized without frequency flag', () => {
+    const ctx = loadAppContext();
+    const before = {
+      drug: 'Metformin',
+      frequency: 'two tabs po bid with meals',
+      route: ''
+    };
+    const after = {
+      drug: 'Metformin ER',
+      frequency: '2 tabs orally two times a day with food',
+      route: ''
+    };
+    const result = ctx.getChangeReason(before, after);
+    expect(result.includes('Frequency changed')).toBe(false);
+  });
+
   test('Inhaler brand swap not flagged as frequency change', () => {
     const ctx = loadAppContext();
     const before = ctx.parseOrder(


### PR DESCRIPTION
## Summary
- add test covering meals/food frequency wording
- normalize `with food` in `canon` so frequency is treated as TID

## Testing
- `npm test`