### PR TITLE
Fix inhaler freq comparisons

### DIFF
--- a/index.html
+++ b/index.html
@@ -2808,9 +2808,27 @@ if (!qtyMatch || taperDiff || courseDiff) {
     freqNumeric(orig.frequency) === freqNumeric(updated.frequency);
 
   // Treat numeric equivalence as "same", even if wording differs.
-  // Also treat inhaler brand swaps as same when numeric freq equal.
-  if (freqSame || (inhaled(orig) && inhaled(updated) && freqSame)) {
-    // Prevent a Frequency flag later
+  if (freqSame) {
+    frequencyMatch = true;
+    freqSameNum = true;
+  }
+
+  // Inhaler brand swaps with equal numeric frequency should not flag a change
+  if (
+    inhaled(orig) &&
+    inhaled(updated) &&
+    freqNumeric(orig.frequency) === freqNumeric(updated.frequency)
+  ) {
+    frequencyMatch = true;
+    freqSameNum = true;
+  }
+
+  // Daily vs daily with only time-of-day difference shouldn't flag frequency
+  if (
+    canon(orig.frequency, orig.originalRaw) === 'daily' &&
+    canon(updated.frequency, updated.originalRaw) === 'daily' &&
+    todChanged(orig, updated)
+  ) {
     frequencyMatch = true;
     freqSameNum = true;
   }
@@ -2869,7 +2887,7 @@ if (orig.prn !== updated.prn) {
 } else if (
   orig.prn &&
   updated.prn &&
-  orig.prnCondition !== updated.prnCondition &&
+  normalizeIndication(orig.prnCondition) !== normalizeIndication(updated.prnCondition) &&
   !changes.includes('Indication changed')
 ) {
   changes.push('Indication changed');

--- a/tests/changeReason.test.js
+++ b/tests/changeReason.test.js
@@ -45,7 +45,7 @@ describe('getChangeReason', () => {
     expect(result).toBe('Brand/Generic changed');
   });
 
-  test('Inhaler vs Respiclick brand swap flagged correctly', () => {
+test('Inhaler vs Respiclick brand swap flagged correctly', () => {
     const ctx = loadAppContext();
     const before = ctx.parseOrder(
       'Albuterol HFA 90 mcg 2 puffs PRN'
@@ -55,5 +55,43 @@ describe('getChangeReason', () => {
     );
     const result = ctx.getChangeReason(before, after);
     expect(result).toBe('Brand/Generic changed');
+  });
+
+  test('Inhaler brand swap \u2013 no frequency flag', () => {
+    const ctx = loadAppContext();
+    const diff = ctx.getChangeReason(
+      {
+        drug: 'Albuterol HFA Inhaler',
+        frequency: '2 puffs every 4-6h prn',
+        form: 'inhaler',
+        route: 'inhalation',
+        prn: true,
+        prnCondition: 'wheezing'
+      },
+      {
+        drug: 'ProAir Respiclick',
+        frequency: 'Inhale 2 puffs q6h prn',
+        form: 'inhaler',
+        route: 'inhalation',
+        prn: true,
+        prnCondition: 'shortness of breath'
+      }
+    );
+    expect(diff).toBe('Brand/Generic changed');
+  });
+
+  test('Warfarin vs Coumadin \u2013 time-of-day only', () => {
+    const ctx = loadAppContext();
+    const diff = ctx.getChangeReason(
+      { drug: 'Warfarin', frequency: 'daily', timeOfDay: '', brandTokens: [], route: '' },
+      {
+        drug: 'Coumadin',
+        frequency: 'daily',
+        timeOfDay: 'evening',
+        brandTokens: ['coumadin'],
+        route: ''
+      }
+    );
+    expect(diff).toBe('Brand/Generic changed, Time of day changed');
   });
 });


### PR DESCRIPTION
## Summary
- treat inhaler brand swaps with same numeric frequency as unchanged
- suppress frequency flag when daily freq differs only by time of day
- normalize PRN condition comparisons
- add regression tests for inhaler and Coumadin brand scenarios

## Testing
- `npm test`