### PR TITLE
Improve brand/generic swap detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -2543,6 +2543,30 @@ function getChangeReason(orig, updated) {
       add('Brand/Generic changed');
     }
   }
+  // Detect brand substitution when both sides specify different brand tokens
+  if (
+    generic1 === generic2 &&
+    leftHasBrand &&
+    rightHasBrand
+  ) {
+    const set1 = new Set((orig.brandTokens || []).map(t => t.toLowerCase()));
+    const set2 = new Set((updated.brandTokens || []).map(t => t.toLowerCase()));
+    let brandDiff = false;
+    if (set1.size !== set2.size) {
+      brandDiff = true;
+    } else {
+      for (const t of set1) {
+        if (!set2.has(t)) { brandDiff = true; break; }
+      }
+    }
+    if (brandDiff) {
+      const lt = (orig.brandTokens || [])[0] || '';
+      const rt = (updated.brandTokens || [])[0] || '';
+      if (!benignBrandSet.has(lt) && !benignBrandSet.has(rt)) {
+        add('Brand/Generic changed');
+      }
+    }
+  }
   const same = (a,b) => (!a && !b) || a===b;
   const sameRoute = (r1, r2) => {
     const normalize = s => (s || '').toLowerCase().trim();

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -7,7 +7,7 @@ describe('Medication comparison', () => {
     const p1 = ctx.parseOrder(before);
     const p2 = ctx.parseOrder(after);
     const result = ctx.getChangeReason(p1, p2);
-    expect(result).toBe('Dose changed, Form changed');
+    expect(result).toBe('Dose changed, Brand/Generic changed, Form changed');
   });
 
   test('adding nerve pain indication ignored when original blank', () => {

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -104,7 +104,7 @@ addTest('Metformin evening vs nightly time change', () => {
 addTest('Vitamin D brand/generic without formulation change', () => {
   const before = 'Cholecalciferol 5000 IU softgel - One weekly';
   const after = 'Vitamin D3 2000 units capsule - One daily';
-  expect(diff(before, after)).toBe('Dose changed, Frequency changed, Form changed');
+  expect(diff(before, after)).toBe('Dose changed, Frequency changed, Brand/Generic changed, Form changed');
 });
 
 addTest('Fluticasone spray dose total', () => {
@@ -158,7 +158,7 @@ addTest('Alprazolam PRN change detected', () => {
 addTest('Vitamin D change list enumerated', () => {
   const before = 'Cholecalciferol 5000 IU softgel – One weekly';
   const after = 'Vitamin D3 2000 units capsule – One daily';
-  expect(diff(before, after)).toBe('Dose changed, Frequency changed, Form changed');
+  expect(diff(before, after)).toBe('Dose changed, Frequency changed, Brand/Generic changed, Form changed');
 });
 
 addTest('Clonidine enumerate changes', () => {
@@ -180,7 +180,7 @@ addTest('Spiriva brand/generic flag', () => {
     'Tiotropium Bromide (Spiriva HandiHaler) 18mcg capsule - Inhale contents of one capsule via HandiHaler once daily';
   const after =
     'Spiriva Respimat 2.5mcg/actuation - 2 inhalations once daily';
-  expect(diff(before, after)).toBe('Dose changed, Form changed');
+  expect(diff(before, after)).toBe('Dose changed, Brand/Generic changed, Form changed');
 });
 
 addTest('HCTZ abbreviation no brand flag', () => {


### PR DESCRIPTION
## Summary
- flag brand/generic swaps when both sides list different brand names but map to the same generic
- adjust expectations for Spiriva and Vitamin D brand swap tests

## Testing
- `npm test`