### PR TITLE
Fix frequency flag when only time of day shifts

### DIFF
--- a/__tests__/changeReason.test.ts
+++ b/__tests__/changeReason.test.ts
@@ -1,0 +1,8 @@
+import { parseOrder } from '../src/parseOrder';
+import { getChangeReason } from '../src/getChangeReason';
+
+test('daily same frequency time-of-day only', () => {
+  const orig = parseOrder('Metformin 500 mg tablet - take 1 tablet daily in the morning');
+  const upd = parseOrder('Metformin 500 mg tablet - take 1 tablet daily in the evening');
+  expect(getChangeReason(orig, upd)).toBe('Time of day changed');
+});

--- a/index.html
+++ b/index.html
@@ -2893,6 +2893,16 @@ if (!freqSameNum) {
 ) {
   freqChange = true;
 }
+if (
+  freqChange &&
+  freqSameNum &&
+  normalizeFrequency(orig.frequency) ===
+    normalizeFrequency(updated.frequency) &&
+  todChanged(orig, updated) &&
+  tokensEqual(orig.frequencyTokens, updated.frequencyTokens)
+) {
+  freqChange = false;
+}
 if (freqChange) add('Frequency changed');
 
 // --- Time of Day Change ---


### PR DESCRIPTION
## Summary
- refine frequency change logic in `getChangeReason`
- add regression test covering same-frequency daily orders with different times of day

## Testing
- `npm test`