### PR TITLE
Fix indication-only brand detection

### DIFF
--- a/__tests__/changeReason.test.ts
+++ b/__tests__/changeReason.test.ts
@@ -6,3 +6,9 @@ test('daily same frequency time-of-day only', () => {
   const upd = parseOrder('Metformin 500 mg tablet - take 1 tablet daily in the evening');
   expect(getChangeReason(orig, upd)).toBe('Time of day changed');
 });
+
+test('indication-only keeps brand switch', () => {
+  const orig = parseOrder('Albuterol HFA Inhaler 90 mcg/puff - 2 puffs q4-6h PRN wheezing');
+  const upd = parseOrder('ProAir Respiclick 90 mcg/inhalation - inhale 2 puffs q6h PRN shortness of breath');
+  expect(getChangeReason(orig, upd)).toMatch(/Brand\/Generic changed/);
+});

--- a/index.html
+++ b/index.html
@@ -2960,6 +2960,7 @@ if (indicationDiff) {
 // 2) **Indication-only**
   if (
     drugNameMatchStrict && // Use the strict substance name match
+    tokensEqual(orig.brandTokens, updated.brandTokens) && // ensure no brand swap
     doseTotalMatch &&     // Use total dose for comparison
     doseUnitMatch &&
     qtyMatch &&           // Check quantity


### PR DESCRIPTION
## Summary
- preserve Brand/Generic changed flag when indication is the only other difference
- test coverage for indication-only brand switch

## Testing
- `npm test`