### PR TITLE
Fix freq change suppression & add test

### DIFF
--- a/__tests__/changeReason.test.ts
+++ b/__tests__/changeReason.test.ts
@@ -12,3 +12,10 @@ test('indication-only keeps brand switch', () => {
   const upd = parseOrder('ProAir Respiclick 90 mcg/inhalation - inhale 2 puffs q6h PRN shortness of breath');
   expect(getChangeReason(orig, upd)).toMatch(/Brand\/Generic changed/);
 });
+
+test('daily same-freq TOD only', () => {
+  const o = 'Warfarin 2.5 mg 1 tab po daily';
+  const u = 'Coumadin 2.5 mg 1 tab po daily in evening';
+  expect(getChangeReason(parseOrder(o), parseOrder(u)))
+    .toBe('Brand/Generic changed, Time of day changed');
+});

--- a/index.html
+++ b/index.html
@@ -2903,6 +2903,15 @@ if (
 ) {
   freqChange = false;
 }
+const freqTokensEqual = tokensEqual(orig.frequencyTokens, updated.frequencyTokens);
+if (
+  freqSameNum &&
+  normalizeFrequency(orig.frequency) === normalizeFrequency(updated.frequency) &&
+  todChanged(orig, updated) &&
+  freqTokensEqual
+) {
+  freqChange = false;
+}
 if (freqChange) add('Frequency changed');
 
 // --- Time of Day Change ---


### PR DESCRIPTION
## Summary
- ensure frequency change not flagged when only time-of-day differs
- cover coumadin/warfarin daily change with new regression test

## Testing
- `npm test`