### PR TITLE
Fix brand swap flag in getChangeReason

### DIFF
--- a/__tests__/changeReason.test.ts
+++ b/__tests__/changeReason.test.ts
@@ -19,3 +19,10 @@ test('daily same-freq TOD only', () => {
   expect(getChangeReason(parseOrder(o), parseOrder(u)))
     .toBe('Brand/Generic changed, Time of day changed');
 });
+
+test('brand swap keeps flag', () => {
+  const o = 'Albuterol HFA 90 mcg 2 puffs q4-6h PRN wheezing';
+  const u = 'ProAir Respiclick 90 mcg inhale 2 puffs q6h PRN sob';
+  expect(getChangeReason(parseOrder(o), parseOrder(u)))
+    .toMatch(/Brand\/Generic changed/);
+});

--- a/index.html
+++ b/index.html
@@ -2967,9 +2967,10 @@ if (indicationDiff) {
 }
  
 // 2) **Indication-only**
-  if (
+  if (!tokensEqual(orig.brandTokens, updated.brandTokens)) {
+    // brand or generic difference - skip this shortcut
+  } else if (
     drugNameMatchStrict && // Use the strict substance name match
-    tokensEqual(orig.brandTokens, updated.brandTokens) && // ensure no brand swap
     doseTotalMatch &&     // Use total dose for comparison
     doseUnitMatch &&
     qtyMatch &&           // Check quantity


### PR DESCRIPTION
## Summary
- avoid clearing Brand/Generic change flag in indication-only logic
- add regression test for brand swap

## Testing
- `npm test`