### PR TITLE
Fix brand change detection when generic names match

### DIFF
--- a/__tests__/changeReason.test.ts
+++ b/__tests__/changeReason.test.ts
@@ -26,3 +26,10 @@ test('brand swap keeps flag', () => {
   expect(getChangeReason(parseOrder(o), parseOrder(u)))
     .toMatch(/Brand\/Generic changed/);
 });
+
+test('ProAir vs Albuterol flags brand change', () => {
+  const o = 'Albuterol HFA Inhaler 90 mcg 2 puffs q4-6h PRN wheeze';
+  const u = 'ProAir Respiclick 90 mcg inhale 2 puffs q6h PRN sob';
+  expect(getChangeReason(parseOrder(o), parseOrder(u)))
+    .toMatch(/Brand\/Generic changed/);
+});

--- a/index.html
+++ b/index.html
@@ -2516,6 +2516,22 @@ function getChangeReason(orig, updated) {
   const leftHasBrand  = (orig.brandTokens || []).length > 0;
   const rightHasBrand = (updated.brandTokens || []).length > 0;
 
+  /* ---------- extra brand/generic guard ---------- */
+  if (!changes.includes('Brand/Generic changed')) {
+    const sameGeneric = norm(orig.drug) === norm(updated.drug);
+    const lt = (orig.brandTokens || [])[0] || '';
+    const rt = (updated.brandTokens || [])[0] || '';
+    if (
+      rawNamesDiffer &&
+      sameGeneric &&
+      (leftHasBrand || rightHasBrand) &&
+      !benignBrandSet.has(lt) &&
+      !benignBrandSet.has(rt)
+    ) {
+      changes.push('Brand/Generic changed');
+    }
+  }
+
   const sameMgStrength = (a, b) => {
     const grab = s => {
       const m = (s || '').match(/(\d+(?:\.\d+)?)\s*mg\b/i);


### PR DESCRIPTION
## Summary
- detect brand/generic substitution even if one side lacks a brand token
- add regression test for ProAir vs Albuterol case

## Testing
- `npm test`