### PR TITLE
Fix daily time-of-day frequency

### DIFF
--- a/index.html
+++ b/index.html
@@ -2919,12 +2919,10 @@ if (
 ) {
   freqChange = false;
 }
-const freqTokensEqual = tokensEqual(orig.frequencyTokens, updated.frequencyTokens);
 if (
   freqSameNum &&
   normalizeFrequency(orig.frequency) === normalizeFrequency(updated.frequency) &&
-  todChanged(orig, updated) &&
-  freqTokensEqual
+  todChanged(orig, updated)
 ) {
   freqChange = false;
 }

--- a/tests/changeReason.test.js
+++ b/tests/changeReason.test.js
@@ -94,4 +94,12 @@ test('Inhaler vs Respiclick brand swap flagged correctly', () => {
     );
     expect(diff).toBe('Brand/Generic changed, Time of day changed');
   });
+
+  test('Coumadin evening vs Warfarin daily \u2014 no freq change', () => {
+    const ctx = loadAppContext();
+    const o = 'Warfarin 2.5 mg 1 tab po daily';
+    const u = 'Coumadin 2.5 mg 1 tab po daily in evening';
+    const reason = ctx.getChangeReason(ctx.parseOrder(o), ctx.parseOrder(u));
+    expect(/Frequency changed/.test(reason)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- avoid frequency flag when two once-daily orders only differ by time-of-day wording
- add regression test for warfarin vs coumadin evening

## Testing
- `npm test`