### PR TITLE
Fix brand↔generic detection & priority order

### DIFF
--- a/index.html
+++ b/index.html
@@ -2463,6 +2463,10 @@ function getChangeReason(orig, updated) {
   const base1 = stripStrength(orig.drug);
   const base2 = stripStrength(updated.drug);
 
+  const leftHasBrand  = (orig.brandTokens || []).length > 0;
+  const rightHasBrand = (updated.brandTokens || []).length > 0;
+
+
   const generic1 = brandToGenericMap[base1] || coreDrugName(base1);
   const generic2 = brandToGenericMap[base2] || coreDrugName(base2);
 
@@ -2480,6 +2484,19 @@ function getChangeReason(orig, updated) {
     !changes.includes('Brand/Generic changed')
   ) {
     changes.push('Brand/Generic changed');
+  }
+
+  /* Capture Brand ↔ Generic when the underlying substance matches
+     (e.g. ProAir ↔ Albuterol).  Use core names so salts/HFA/etc. are
+     ignored. */
+  const substance1 = brandToGenericMap[gen1] || gen1;
+  const substance2 = brandToGenericMap[gen2] || gen2;
+  if (
+    substance1 === substance2 &&
+    leftHasBrand !== rightHasBrand &&
+    !changes.includes('Brand/Generic changed')
+  ) {
+    add('Brand/Generic changed');
   }
 
   const norm = s => (s || '').toLowerCase().trim().replace(/\s+/g, ' ');
@@ -2520,9 +2537,6 @@ function getChangeReason(orig, updated) {
   const drugNameMatchStrict = origDrugNorm === updatedDrugNorm; // Based on fully normalized names (substance match)
   // New: direct raw-name comparison for certain brand/generic swaps
   const rawNamesDiffer = norm(origDrugNameRaw) !== norm(updatedDrugNameRaw);
-
-  const leftHasBrand  = (orig.brandTokens || []).length > 0;
-  const rightHasBrand = (updated.brandTokens || []).length > 0;
 
   /* ---------- extra brand/generic guard ---------- */
   if (!changes.includes('Brand/Generic changed')) {
@@ -3126,7 +3140,20 @@ if (indicationDiff) {
   if (changes.length === 1) return changes[0];
   if (changes.length <= 4) { // List up to 4 specific changes
       // Prioritize more significant changes if too many minor ones
-      const priorityOrder = ["Dose changed", "Frequency changed", "Formulation changed", "Quantity changed", "Brand/Generic changed", "Route changed", "Administration changed", "Form changed", "PRN changed", "Indication changed", "Date changed", "End Date changed", "Time of day changed"];
+      const priorityOrder = [
+        'Dose changed',
+        'Frequency changed',
+        'Formulation changed',
+        'Brand/Generic changed',
+        'Quantity changed',
+        'Route changed',
+        'Form changed',
+        'Time of day changed',
+        'Administration changed',
+        'Indication changed',
+        'Date changed',
+        'End Date changed'
+      ];
       changes.sort((a, b) => {
           let idxA = priorityOrder.indexOf(a);
           let idxB = priorityOrder.indexOf(b);

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -382,21 +382,21 @@ addTest('Klor-Con brand only', () => {
 addTest('Tylenol brand flag', () => {
   const b = 'Tylenol 500 mg 2 tabs PO q6h prn pain';
   const a = 'Acetaminophen 1000 mg tab PO every 6 hours as needed for pain';
-  expect(diff(b, a)).toBe('Dose changed, Quantity changed, Brand/Generic changed');
+  expect(diff(b, a)).toBe('Dose changed, Brand/Generic changed, Quantity changed');
 });
 
 addTest('Implicit tablet form same', () => {
   const before = 'Tylenol 500 mg 2 tabs PO q6h prn pain';
   const after  = 'Acetaminophen 1000 mg PO every 6 hours as needed for pain';
   expect(diff(before, after))
-    .toBe('Dose changed, Quantity changed, Brand/Generic changed');
+    .toBe('Dose changed, Brand/Generic changed, Quantity changed');
 });
 
 addTest('Tabs vs no form equal', () => {
   const before = 'Tylenol 500 mg 2 tabs po q6h prn pain';
   const after  = 'Acetaminophen 1000 mg po every 6 h as needed for pain';
   expect(diff(before, after))
-    .toBe('Dose changed, Quantity changed, Brand/Generic changed');
+    .toBe('Dose changed, Brand/Generic changed, Quantity changed');
 });
 
 addTest('Metoprolol XL vs ER unchanged', () => {
@@ -875,7 +875,7 @@ addTest('benign brand swaps', () => {
   expect(diff('ProAir 90 mcg 2 puffs PRN', 'Albuterol HFA 90 mcg 2 puffs PRN'))
     .toBe('Brand/Generic changed');
   expect(diff('K-Dur 10 mEq ER tab BID', 'Potassium Chloride 10 mEq ER tab BID'))
-    .toBe('');
+    .toBe('Brand/Generic changed');
   expect(diff('Lasix 20 mg qAM', 'Furosemide 20 mg daily')).toBe(
     'Brand/Generic changed'
   );


### PR DESCRIPTION
## Summary
- detect brand/generic swap when brands map to the same substance
- prioritize brand/generic change above quantity/form
- update unit tests for new ordering and detection

## Testing
- `npm run lint`
- `npm test`