### PR TITLE
Fix time-of-day flag logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -3101,6 +3101,20 @@ if (indicationDiff) {
   ) {
     changes = changes.filter(c => c !== 'Time of day changed');
   }
+
+  // ── NEW CLEANUP: drop redundant Time-of-day flag ────────────────
+  if (
+    changes.includes('Frequency changed') &&
+    changes.includes('Time of day changed')
+  ) {
+    const onceDaily = ['daily', 'qam', 'qpm', 'qhs', 'hs', 'nightly'];
+    const f1 = canon(orig.frequency);
+    const f2 = canon(updated.frequency);
+    if (!onceDaily.includes(f1) || !onceDaily.includes(f2)) {
+      changes = changes.filter(c => c !== 'Time of day changed');
+    }
+  }
+  // ────────────────────────────────────────────────────────────────
   // collapse inhaler form/route double-hit
   if (changes.includes('Form changed') && changes.includes('Route changed') && inhaled(orig) && inhaled(updated)) { // check if both are inhaled
     changes = changes.filter(c => c !== 'Route changed'); // or form, depending on preference

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -162,7 +162,7 @@ describe('Medication comparison', () => {
     const before = 'Metformin 500 mg tablet po BID';
     const after = 'Metformin 500 mg tablet - take 1 tab every morning';
     const result = ctx.getChangeReason(ctx.parseOrder(before), ctx.parseOrder(after));
-    expect(result).toBe('Frequency changed, Time of day changed');
+    expect(result).toBe('Frequency changed');
   });
 
   test('does not flag formulation on K-Dur vs KCl ER', () => {

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -99,7 +99,7 @@ require('./issueRegressions.test');
 addTest('Metformin evening vs nightly time change', () => {
   const before = 'Metformin 500 mg tablet po BID';
   const after = 'Metformin 500 mg tablet - take 1 tab every morning';
-  expect(diff(before, after)).toBe('Frequency changed, Time of day changed');
+  expect(diff(before, after)).toBe('Frequency changed');
 });
 
 addTest('Vitamin D brand/generic without formulation change', () => {


### PR DESCRIPTION
## Summary
- clean up redundant `Time of day changed` flag when frequency also changed
- update tests for new logic

## Testing
- `npm test`