### PR TITLE
Add once-daily vs TID test

### DIFF
--- a/tests/getChangeReason.test.js
+++ b/tests/getChangeReason.test.js
@@ -1,5 +1,5 @@
 describe('getChangeReason', () => {
-  const cases = [
+  const pairs = [
     [
       'Albuterol HFA 90 mcg 2 puffs q4-6h PRN wheeze',
       'ProAir Respiclick 90 mcg inhale 2 puffs q6h PRN sob'
@@ -10,9 +10,20 @@ describe('getChangeReason', () => {
     ]
   ];
 
-  test.each(cases)('Albuterol \u2194 ProAir keeps Brand flag (%s => %s)', (o, u) => {
+  for (const [o, u] of pairs) {
+    test(`Albuterol \u2194 ProAir keeps Brand flag (${o} => ${u})`, () => {
+      const ctx = loadAppContext();
+      const r = ctx.getChangeReason(ctx.parseOrder(o), ctx.parseOrder(u));
+      expect(r).toMatch(/Brand\/Generic changed/);
+    });
+  }
+
+  test('Once-daily \u279c TID keeps frequency but drops TOD', () => {
     const ctx = loadAppContext();
+    const o = 'Gabapentin 300 mg 1 cap at bedtime';
+    const u = 'Gabapentin 300 mg 1 cap three times daily';
     const r = ctx.getChangeReason(ctx.parseOrder(o), ctx.parseOrder(u));
-    expect(r).toMatch(/Brand\/Generic changed/);
+    expect(r).toMatch(/Frequency changed/);
+    expect(/Time of day changed/.test(r)).toBe(false);
   });
 });

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -94,6 +94,7 @@ global.loadAppContext = loadAppContext;
 require('./medDiff.test');
 require('./helpers.test');
 require('./changeReason.test');
+require('./getChangeReason.test');
 require('./issueRegressions.test');
 
 addTest('Metformin evening vs nightly time change', () => {


### PR DESCRIPTION
## Summary
- add missing test coverage for Time of day vs frequency logic
- include `getChangeReason.test.js` in custom test runner

## Testing
- `npm test`
