### PR TITLE
Fix time-of-day flag for critical anticoagulants

### DIFF
--- a/index.html
+++ b/index.html
@@ -3120,6 +3120,21 @@ if (indicationDiff) {
     changes = changes.filter(c => c !== 'Route changed'); // or form, depending on preference
   }
 
+  /* --- CRITICAL TIME-OF-DAY RULE ------------------------------------ */
+  const criticalTodDrug =
+    ['warfarin','coumadin','apixaban','eliquis','rivaroxaban','xarelto',
+     'dabigatran','pradaxa','edoxaban','lixiana',
+     'heparin','enoxaparin','lovenox'].some(d =>
+       generic1 === d || generic2 === d
+     );
+
+  if (criticalTodDrug &&
+      !changes.includes('Time of day changed') &&
+      todChanged(orig, updated)) {
+    changes.push('Time of day changed');
+  }
+  /* -------------------------------------------------------------------- */
+
 // --- New Rule for Stat/Immediately vs. Timed Dosing ---
   const origFreqIsImmediately = norm(orig.frequency) === 'immediately';
   const updatedFreqIsDaily =

--- a/tests/issueRegressions.test.js
+++ b/tests/issueRegressions.test.js
@@ -50,4 +50,12 @@ describe('issue regressions', () => {
     expect(reason.includes('Time of day changed')).toBe(true);
     expect(reason.includes('Frequency changed')).toBe(false);
   });
+
+  test('Warfarin bedtime switch keeps TOD flag', () => {
+    const ctx = loadAppContext();
+    const o = 'Warfarin 2.5 mg tablet take 1 PO every morning';
+    const u = 'Coumadin 2.5 mg tablet take 1 PO daily in the evening';
+    const r = ctx.getChangeReason(ctx.parseOrder(o), ctx.parseOrder(u));
+    expect(r).toMatch(/Time of day changed/);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure time of day changes are kept for critical anticoagulants even when combined with brand/generic or frequency changes
- add regression test for warfarin bedtime switch

## Testing
- `npm test`