### PR TITLE
Fix frequency mismatch detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -3114,6 +3114,15 @@ if (indicationDiff) {
       changes = changes.filter(c => c !== 'Time of day changed');
     }
   }
+
+  /* ——— NEW: drop a bogus Frequency-changed when both sides normalise
+              to the *same* frequency ——— */
+  if (
+    changes.includes('Frequency changed') &&
+    normalizeFrequency(orig.frequency) === normalizeFrequency(updated.frequency)
+  ) {
+    changes = changes.filter(c => c !== 'Frequency changed');
+  }
   // ────────────────────────────────────────────────────────────────
   // collapse inhaler form/route double-hit
   if (changes.includes('Form changed') && changes.includes('Route changed') && inhaled(orig) && inhaled(updated)) { // check if both are inhaled

--- a/tests/issueRegressions.test.js
+++ b/tests/issueRegressions.test.js
@@ -58,4 +58,13 @@ describe('issue regressions', () => {
     const r = ctx.getChangeReason(ctx.parseOrder(o), ctx.parseOrder(u));
     expect(r).toMatch(/Time of day changed/);
   });
+
+  test('Warfarin vs Coumadin keeps TOD flag', () => {
+    const ctx = loadAppContext();
+    const o = 'Warfarin 2.5 mg \u2013 take 1 tablet PO daily';
+    const u = 'Coumadin 2.5 mg \u2013 1 tablet PO daily in the evening';
+    const r = ctx.getChangeReason(ctx.parseOrder(o), ctx.parseOrder(u));
+    expect(r).toMatch(/Time of day changed/);
+    expect(/Frequency changed/.test(r)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- suppress bogus 'Frequency changed' when frequencies normalize to the same value
- add regression test for Warfarin vs Coumadin daily

## Testing
- `npm test`