### PR TITLE
Add regression test for Coumadin time change

### DIFF
--- a/tests/issueRegressions.test.js
+++ b/tests/issueRegressions.test.js
@@ -67,4 +67,12 @@ describe('issue regressions', () => {
     expect(r).toMatch(/Time of day changed/);
     expect(/Frequency changed/.test(r)).toBe(false);
   });
+
+  test('Warfarin vs Coumadin keeps TOD flag (no bogus Frequency)', () => {
+    const o = 'Warfarin 2.5 mg \u2013 1 tablet PO daily';
+    const u = 'Coumadin 2.5 mg \u2013 1 tablet PO daily in the evening';
+    const r = getChangeReason(parseOrder(o), parseOrder(u));
+    expect(r).toMatch(/Time of day changed/);
+    expect(r).not.toMatch(/Frequency changed/);
+  });
 });

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -45,6 +45,11 @@ global.expect = actual => ({
       if (actual === expected) {
         throw new Error(`Expected value not to be ${expected}`);
       }
+    },
+    toMatch: regex => {
+      if (regex.test(String(actual))) {
+        throw new Error(`Expected ${actual} not to match ${regex}`);
+      }
     }
   }
 });
@@ -90,6 +95,10 @@ function diffRowsList(beforeList, afterList) {
 global.diffRowsList = diffRowsList;
 global.diffRows = diffRowsList;
 global.loadAppContext = loadAppContext;
+// Expose core helpers for convenience in tests
+global.parseOrder = (...args) => loadAppContext().parseOrder(...args);
+global.getChangeReason = (...args) =>
+  loadAppContext().getChangeReason(...args);
 
 require('./medDiff.test');
 require('./helpers.test');


### PR DESCRIPTION
## Summary
- expose `parseOrder` and `getChangeReason` in the test harness
- add `expect.not.toMatch` helper
- verify Coumadin evening switch keeps time-of-day flag without a frequency change

## Testing
- `npm test`