### PR TITLE
Fix TOD vs frequency handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -3062,6 +3062,25 @@ if (indicationDiff) {
       console.log('--- BLOCK #3 CONDITION FAILED for explicit Time of Day return ---');
   }
 
+  /* ---------- TIME-OF-DAY vs SAME-FREQUENCY GUARD ---------- */
+  {
+    const sameNumFreq = (() => {
+      const n1 = freqNumeric(orig.frequency);
+      const n2 = freqNumeric(updated.frequency);
+      return n1 != null && n1 === n2;
+    })();
+
+    if (sameNumFreq && todChanged(orig, updated) && !timeOfDayMatch) {
+      /* Ensure TOD tag is present */
+      if (!changes.includes('Time of day changed')) {
+        changes.push('Time of day changed');
+      }
+      /* …and drop the redundant freq tag */
+      changes = changes.filter(c => c !== 'Frequency changed');
+    }
+  }
+  /* ---------------------------------------------------------- */
+
   if (changes.includes('Dose changed') && coumBrand) {
     if (doseTotalMatch || sameMgStrength(origDrugNameRaw, updatedDrugNameRaw)) {
       changes = changes.filter(c => c !== 'Dose changed');

--- a/tests/issueRegressions.test.js
+++ b/tests/issueRegressions.test.js
@@ -75,4 +75,12 @@ describe('issue regressions', () => {
     expect(r).toMatch(/Time of day changed/);
     expect(r).not.toMatch(/Frequency changed/);
   });
+
+  test('Daily vs Daily-in-evening keeps TOD tag only', () => {
+    const o = 'Warfarin 2.5 mg take 1 tab daily';
+    const u = 'Coumadin 2.5 mg take 1 tab daily in the evening';
+    const r = getChangeReason(parseOrder(o), parseOrder(u));
+    expect(r).toMatch(/Time of day changed/);
+    expect(r).not.toMatch(/Frequency changed/);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure once-daily orders with a new time of day keep the TOD flag and drop redundant frequency change
- add regression test for daily -> daily in evening case

## Testing
- `npm test`
- `npm run lint`