### PR TITLE
Fix TOD vs frequency cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -3203,6 +3203,33 @@ if (indicationDiff) {
     changes = changes.filter(c => c !== 'Frequency changed');
   }
 
+  /* ---------- FINAL TOD vs FREQ SANITY PASS ---------- */
+  {
+    const sameNumericFreq = (() => {
+      const n1 = freqNumeric(orig.frequency);
+      const n2 = freqNumeric(updated.frequency);
+      return n1 != null && n1 === n2;
+    })();
+
+    if (sameNumericFreq && todChanged(orig, updated) && !timeOfDayMatch) {
+      const lasixException =
+        canon(orig.frequency, orig.originalRaw) === 'daily' &&
+        canon(updated.frequency, updated.originalRaw) === 'daily' &&
+        ((orig.brandTokens || []).includes('lasix') ||
+          (updated.brandTokens || []).includes('lasix'));
+
+      if (!lasixException) {
+        // Ensure TOD tag present
+        if (!changes.includes('Time of day changed')) {
+          changes.push('Time of day changed');
+        }
+      }
+      // Drop redundant frequency tag
+      changes = changes.filter(c => c !== 'Frequency changed');
+    }
+  }
+  /* ---------------------------------------------------- */
+
   if (changes.length === 0) return 'Unchanged'; // Default to Unchanged if no specific diffs were added
   if (changes.length === 1) return changes[0];
   if (changes.length <= 4) { // List up to 4 specific changes

--- a/tests/issueRegressions.test.js
+++ b/tests/issueRegressions.test.js
@@ -83,4 +83,12 @@ describe('issue regressions', () => {
     expect(r).toMatch(/Time of day changed/);
     expect(r).not.toMatch(/Frequency changed/);
   });
+
+  test('Daily vs daily-in-evening shows TOD, not Frequency', () => {
+    const o = 'Warfarin 2.5 mg take 1 tab daily';
+    const u = 'Coumadin 2.5 mg take 1 tab daily in the evening';
+    const r = getChangeReason(parseOrder(o), parseOrder(u));
+    expect(r).toMatch(/Time of day changed/);
+    expect(r).not.toMatch(/Frequency changed/);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure time-of-day changes aren't lost after cleanup logic
- add regression test for daily vs daily-in-evening

## Testing
- `npm test`