### PR TITLE
Add daily-evening TOD regression test

### DIFF
--- a/tests/issueRegressions.test.js
+++ b/tests/issueRegressions.test.js
@@ -91,4 +91,12 @@ describe('issue regressions', () => {
     expect(r).toMatch(/Time of day changed/);
     expect(r).not.toMatch(/Frequency changed/);
   });
+
+  test('Daily vs daily-in-evening flags TOD only', () => {
+    const o = 'Warfarin 2.5 mg take 1 tab daily';
+    const u = 'Coumadin 2.5 mg take 1 tab daily in the evening';
+    const r = getChangeReason(parseOrder(o), parseOrder(u));
+    expect(r).toMatch(/Time of day changed/);
+    expect(r).not.toMatch(/Frequency changed/);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure daily vs daily-in-evening comparison only flags time-of-day change

## Testing
- `npm test`