### PR TITLE
Comment out Time-of-Day guard block

### DIFF
--- a/index.html
+++ b/index.html
@@ -3062,24 +3062,27 @@ if (indicationDiff) {
       console.log('--- BLOCK #3 CONDITION FAILED for explicit Time of Day return ---');
   }
 
-  /* ---------- TIME-OF-DAY vs SAME-FREQUENCY GUARD ---------- */
-  {
-    const sameNumFreq = (() => {
-      const n1 = freqNumeric(orig.frequency);
-      const n2 = freqNumeric(updated.frequency);
-      return n1 != null && n1 === n2;
-    })();
-
-    if (sameNumFreq && todChanged(orig, updated) && !timeOfDayMatch) {
-      /* Ensure TOD tag is present */
-      if (!changes.includes('Time of day changed')) {
-        changes.push('Time of day changed');
-      }
-      /* …and drop the redundant freq tag */
-      changes = changes.filter(c => c !== 'Frequency changed');
-    }
-  }
-  /* ---------------------------------------------------------- */
+  /* ---------- TIME-OF-DAY vs SAME-FREQUENCY GUARD ----------
+   * Block temporarily disabled to prevent premature manipulation
+   * of `changes`
+   *
+   * {
+   *   const sameNumFreq = (() => {
+   *     const n1 = freqNumeric(orig.frequency);
+   *     const n2 = freqNumeric(updated.frequency);
+   *     return n1 != null && n1 === n2;
+   *   })();
+   *
+   *   if (sameNumFreq && todChanged(orig, updated) && !timeOfDayMatch) {
+   *     / * Ensure TOD tag is present * /
+   *     if (!changes.includes('Time of day changed')) {
+   *       changes.push('Time of day changed');
+   *     }
+   *     / * …and drop the redundant freq tag * /
+   *     changes = changes.filter(c => c !== 'Frequency changed');
+   *   }
+   * }
+   * ---------------------------------------------------------- */
 
   if (changes.includes('Dose changed') && coumBrand) {
     if (doseTotalMatch || sameMgStrength(origDrugNameRaw, updatedDrugNameRaw)) {


### PR DESCRIPTION
## Summary
- disable the Time-of-Day vs Same-Frequency guard to stop early mutation of `changes`

## Testing
- `npm run lint`
- `npm test`
