### PR TITLE
Document parseOrder refactor plan

### DIFF
--- a/docs/refactor-parseOrder.md
+++ b/docs/refactor-parseOrder.md
@@ -1,0 +1,60 @@
+# Refactoring Plan for `parseOrder`
+
+The current `parseOrder` implementation in `index.html` spans over 800 lines and handles
+string normalization, dose parsing, frequency logic and final cleanup in one
+monolithic function. According to the guidelines in `AGENT.md`, complex
+functions should be decomposed into single‑responsibility helpers located under
+`/src`.
+
+This document outlines a proposed breakdown:
+
+1. **Preprocessing**
+   - Convert unusual hyphens and normalize text.
+   - Capture and strip trailing trough monitoring notes.
+   - Helper: `preprocessOrderString(orderStr)`.
+
+2. **Initial Order Object**
+   - Build a fresh order object with all expected fields.
+   - Helper: `initOrderObject(originalRaw)`.
+
+3. **Taper and Date Extraction**
+   - Detect `taper` or `no taper` flags and extract explicit start/end dates.
+   - Helpers: `applyTaperFlags(str, order)`, `extractDatesInfo(str, order)`.
+
+4. **Time‑of‑Day and Frequency**
+   - Handle shorthands such as `qam`, `bedtime`, weekly phrases and tokens
+     that imply frequency.
+   - Helper: `parseTimeOfDay(str, order)`.
+
+5. **Formulation Parsing**
+   - Remove release keywords (`ER`, `IR`, `XL` etc.) from the drug phrase while
+     recording them on the order.
+   - Helper: `parseFormulation(str, order)`.
+
+6. **PRN and Indication**
+   - Extract `prn` flags and any trailing `for ...` indications.
+   - Helper: `parsePrnAndIndication(str, order)`.
+
+7. **Quantity and Dose**
+   - Detect quantity tokens (`2 tabs`) prior to dose parsing to avoid
+     mis‑classification.
+   - Helpers: `parseQuantity(str, order)`, `parseDose(str, order)`.
+
+8. **Form, Route and Frequency**
+   - Determine dosage form (tablet, capsule), administration route and any
+     complex frequency (`q4-6h`, `immediately`).
+   - Helpers: `parseForm(str, order)`, `parseRoute(str, order)`,
+     `parseFrequency(str, order)`.
+
+9. **Drug Name Extraction**
+   - Normalize the remaining string to obtain the drug name and brand tokens.
+   - Helper: `parseDrug(str, order)`.
+
+10. **Final Normalization**
+    - Apply defaulting rules, canonical form names and schedule tokens.
+    - Helper: `finalizeOrder(order, troughNote, originalRaw)`.
+
+Each helper should be small (≈20‑40 lines) and have its own Jest test suite.
+Over time `parseOrder` will become a simple pipeline calling these helpers in
+sequence. Complexity of the new `parseOrder` should remain below 15 per the
+`AGENT.md` guidance.

--- a/src/orderParsingHelpers.js
+++ b/src/orderParsingHelpers.js
@@ -1,0 +1,95 @@
+// Helper stubs for parseOrder refactor
+// These functions will gradually replace inline logic inside index.html.
+// Each function should be pure and easily testable.
+
+export function preprocessOrderString(orderStr) {
+  // TODO: normalize text, strip special characters, capture trough notes
+  return { cleaned: orderStr, troughNote: null };
+}
+
+export function initOrderObject(originalRaw) {
+  return {
+    drug: '',
+    dose: { value: null, unit: '', total: null },
+    qty: null,
+    route: '',
+    frequency: '',
+    frequencyTokens: [],
+    timeOfDay: '',
+    timeOfDayOriginal: '',
+    administration: '',
+    prn: false,
+    prnCondition: '',
+    startDate: '',
+    endDate: '',
+    form: '',
+    formulation: '',
+    indication: '',
+    brandTokens: [],
+    rawDrug: '',
+    rawUnit: '',
+    taperFlag: null,
+    refills: null,
+    originalRaw,
+  };
+}
+
+export function applyTaperFlags(str, order) {
+  // TODO: update order.taperFlag based on 'taper' phrases
+  return str;
+}
+
+export function extractDatesInfo(str, order) {
+  // TODO: extract start and end dates
+  return str;
+}
+
+export function parseTimeOfDay(str, order) {
+  // TODO: set timeOfDay and implied frequency
+  return str;
+}
+
+export function parseFormulation(str, order) {
+  // TODO: detect formulation keywords and clean them from the string
+  return str;
+}
+
+export function parsePrnAndIndication(str, order) {
+  // TODO: parse PRN flags and indications
+  return str;
+}
+
+export function parseQuantity(str, order) {
+  // TODO: detect quantity units and amount
+  return str;
+}
+
+export function parseDose(str, order) {
+  // TODO: extract dose value and unit
+  return str;
+}
+
+export function parseForm(str, order) {
+  // TODO: set dosage form (tablet, capsule, etc.)
+  return str;
+}
+
+export function parseRoute(str, order) {
+  // TODO: detect administration route
+  return str;
+}
+
+export function parseFrequency(str, order) {
+  // TODO: parse complex frequency expressions
+  return str;
+}
+
+export function parseDrug(str, order) {
+  // TODO: final drug and brand/generic tokens
+  return str;
+}
+
+export function finalizeOrder(order, troughNote, originalRaw) {
+  // TODO: apply final normalizations
+  return order;
+}


### PR DESCRIPTION
## Summary
- add helper stubs under `src` for breaking up `parseOrder`
- document plan to refactor the huge `parseOrder` into single-responsibility helpers

The current `parseOrder` function is over 800 lines long, so its complexity far exceeds the recommended limit of 15 in `AGENT.md`.

## Testing
- `npm test`