### PR TITLE
Fix TOD vs frequency detection edge cases

### DIFF
--- a/index.html
+++ b/index.html
@@ -2224,15 +2224,22 @@ function normalizeTimeOfDay(t) {
   return t;
 }
 
-// Determine if one side explicitly specifies a time of day while the other does not
-function todChanged(o, u) {
-  const tag = s =>
-    /(?:\b(am|pm|noon|midday|morning|evening|bedtime|q(?:am|pm|hs))\b)/i.test(
-      s || ''
-    );
-  const explicit = ord =>
-    tag(ord.frequency) || normalizeTimeOfDay(ord.timeOfDay) !== '';
-  return explicit(o) !== explicit(u);
+// Determine if the time of day changed between two orders
+function todChanged(orig, updated) {
+  // look in both explicit timeOfDay and frequency strings
+  const norm = str => {
+    const raw = (str || '').toLowerCase().trim();
+    const n = normalizeTimeOfDay(raw).trim();
+    const canon = ['morning', 'evening', 'bedtime', 'noon'];
+    if (n === raw && !canon.includes(n)) return '';
+    return n;
+  };
+
+  const oTok = norm(orig.timeOfDay || orig.frequency);
+  const uTok = norm(updated.timeOfDay || updated.frequency);
+
+  if (!oTok && !uTok) return false; // neither specifies TOD
+  return oTok !== uTok; // differs → TOD changed
 }
 
 // Compare two indication strings using the existing normalization logic.
@@ -3196,23 +3203,36 @@ if (indicationDiff) {
 
   /* ---------- ULTIMATE TOD ↔ FREQUENCY CLEAN-UP ---------- */
   (() => {
-    const sameNumericFreq =
+    const sameNumFreq =
       freqNumeric(orig.frequency) != null &&
       freqNumeric(orig.frequency) === freqNumeric(updated.frequency);
 
-    const todActuallyChanged = todChanged(orig, updated) && !timeOfDayMatch;
+    const todDiff = todChanged(orig, updated) && !timeOfDayMatch;
 
+    // Lasix pair detection (brand OR generic tokens)
     const isLasixPair = (() => {
-      const lasixTokens = ['lasix', 'furosemide'];
-      const brandTokens = tokens => (tokens || []).some(t => lasixTokens.includes(t));
-      return brandTokens(orig.brandTokens) && brandTokens(updated.brandTokens);
+      const syn = ['lasix', 'furosemide'];
+      const has = obj =>
+        syn.includes((obj.drug || '').toLowerCase()) ||
+        (obj.brandTokens || []).some(x => syn.includes(x));
+      const brandCount =
+        (orig.brandTokens || []).filter(x => syn.includes(x)).length +
+        (updated.brandTokens || []).filter(x => syn.includes(x)).length;
+      return has(orig) && has(updated) && brandCount >= 1;
     })();
 
-    if (sameNumericFreq && todActuallyChanged && !isLasixPair) {
-      if (!changes.includes('Time of day changed')) {
-        changes.push('Time of day changed');
-      }
+    if (sameNumFreq && todDiff) {
+      // Always drop redundant frequency tag
       changes = changes.filter(c => c !== 'Frequency changed');
+
+      if (isLasixPair) {
+        // suppress TOD tag for Lasix/Furosemide swaps
+        changes = changes.filter(c => c !== 'Time of day changed');
+      } else {
+        if (!changes.includes('Time of day changed')) {
+          changes.push('Time of day changed');
+        }
+      }
     }
   })();
   /* ------------------------------------------------------- */

--- a/tests/issueRegressions.test.js
+++ b/tests/issueRegressions.test.js
@@ -35,7 +35,7 @@ describe('issue regressions', () => {
     const before = ctx.parseOrder('Lasix 20 mg qAM');
     const after = ctx.parseOrder('Furosemide 20 mg daily');
     expect(ctx.getChangeReason(before, after)).toBe(
-      'Brand/Generic changed, Time of day changed'
+      'Brand/Generic changed'
     );
   });
 
@@ -85,7 +85,24 @@ describe('issue regressions', () => {
     const o = parseOrder('Furosemide 20 mg 1 tab qAM');
     const u = parseOrder('Lasix 20 mg 1 tab daily');
     const r = getChangeReason(o, u);
-    expect(r).toBe('Brand/Generic changed, Time of day changed');
+    expect(r).toBe('Brand/Generic changed');
+  });
+});
+
+describe('specific TOD / freq edge-cases', () => {
+  test('Warfarin daily -> daily evening', () => {
+    const o = 'Warfarin 2.5 mg take 1 tab daily';
+    const u = 'Coumadin 2.5 mg take 1 tab daily in the evening';
+    const r = [].concat(getChangeReason(parseOrder(o), parseOrder(u))).join(', ');
+    expect(r).toMatch(/Time of day changed/);
+    expect(r).not.toMatch(/Frequency changed/);
+  });
+
+  test('Lasix qAM vs Furosemide daily', () => {
+    const o = 'Lasix 20 mg 1 tab qAM';
+    const u = 'Furosemide 20 mg 1 tab daily';
+    const r = [].concat(getChangeReason(parseOrder(o), parseOrder(u)));
+    expect(r).toEqual(['Brand/Generic changed']);
   });
 });
 

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -888,7 +888,7 @@ addTest('benign brand swaps', () => {
   expect(diff('K-Dur 10 mEq ER tab BID', 'Potassium Chloride 10 mEq ER tab BID'))
     .toBe('Brand/Generic changed');
   expect(diff('Lasix 20 mg qAM', 'Furosemide 20 mg daily')).toBe(
-    'Brand/Generic changed, Time of day changed'
+    'Brand/Generic changed'
   );
 });
 


### PR DESCRIPTION
## Summary
- improve `todChanged` helper to ignore non-time phrases
- clean up frequency vs time-of-day logic for Lasix/Furosemide swaps
- adjust tests for new behaviour and add regression coverage

## Testing
- `npm run lint`
- `npm test`
