### PR TITLE
Refine TOD/frequency cleanup logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -3208,19 +3208,26 @@ if (indicationDiff) {
 
   /* ---------- ULTIMATE TOD ↔ FREQUENCY CLEAN-UP ---------- */
   (() => {
-    if (!sameFrequency(orig.frequency, updated.frequency)) return;
+    const todShifted   = todChanged(orig, updated) && !timeOfDayMatch;
+    const freqNumeric1 = freqNumeric(orig.frequency);
+    const freqNumeric2 = freqNumeric(updated.frequency);
 
-    const todShifted = todChanged(orig, updated) && !timeOfDayMatch;
+    /* 1️⃣  – ALWAYS strip a redundant “Frequency changed” flag when:
+          • numeric schedules are equal  OR
+          • one side is missing but the other is plainly “daily”  */
+    const equalFreq =
+          sameFrequency(orig.frequency, updated.frequency) ||
+          ( (freqNumeric1 === 1 || freqNumeric2 === 1) &&
+            (freqNumeric1 == null || freqNumeric2 == null) );
 
-    // Always drop any stray Frequency flag when numeric schedule is unchanged
-    changes = changes.filter(c => c !== 'Frequency changed');
+    if (equalFreq)
+      changes = changes.filter(c => c !== 'Frequency changed');
 
+    /* 2️⃣  – If an explicit TOD token was added or removed, ensure the tag: */
     if (todShifted) {
-      if (!changes.includes('Time of day changed')) {
+      if (!changes.includes('Time of day changed'))
         changes.push('Time of day changed');
-      }
     } else {
-      // No real TOD difference → remove any lingering tag
       changes = changes.filter(c => c !== 'Time of day changed');
     }
   })();

--- a/tests/getChangeReason.test.js
+++ b/tests/getChangeReason.test.js
@@ -18,12 +18,12 @@ describe('getChangeReason', () => {
     });
   }
 
-  test('Once-daily \u279c TID keeps frequency but drops TOD', () => {
+  test('Once-daily \u279c TID keeps frequency and flags TOD shift', () => {
     const ctx = loadAppContext();
     const o = 'Gabapentin 300 mg 1 cap at bedtime';
     const u = 'Gabapentin 300 mg 1 cap three times daily';
     const r = ctx.getChangeReason(ctx.parseOrder(o), ctx.parseOrder(u));
     expect(r).toMatch(/Frequency changed/);
-    expect(/Time of day changed/.test(r)).toBe(false);
+    expect(r).toMatch(/Time of day changed/);
   });
 });

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -161,8 +161,11 @@ describe('Medication comparison', () => {
     const ctx = loadAppContext();
     const before = 'Metformin 500 mg tablet po BID';
     const after = 'Metformin 500 mg tablet - take 1 tab every morning';
-    const result = ctx.getChangeReason(ctx.parseOrder(before), ctx.parseOrder(after));
-    expect(result).toBe('Frequency changed');
+    const result = ctx.getChangeReason(
+      ctx.parseOrder(before),
+      ctx.parseOrder(after)
+    );
+    expect(result).toBe('Frequency changed, Time of day changed');
   });
 
   test('does not flag formulation on K-Dur vs KCl ER', () => {

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -127,7 +127,7 @@ require('./issueRegressions.test');
 addTest('Metformin evening vs nightly time change', () => {
   const before = 'Metformin 500 mg tablet po BID';
   const after = 'Metformin 500 mg tablet - take 1 tab every morning';
-  expect(diff(before, after)).toBe('Frequency changed');
+  expect(diff(before, after)).toBe('Frequency changed, Time of day changed');
 });
 
 addTest('Vitamin D brand/generic without formulation change', () => {


### PR DESCRIPTION
## Summary
- refine TOD vs frequency cleanup in `index.html`
- update expectations for TOD shifts in tests

## Testing
- `npm test`
- `npm run lint` *(fails: No lint configured)*