### PR TITLE
Handle plural evening strings

### DIFF
--- a/index.html
+++ b/index.html
@@ -2198,12 +2198,14 @@ function normalizeTimeOfDay(t) {
     'in the morning': 'morning',
     'daily in morning': 'morning',
     evening: 'evening',
+    evenings: 'evening',
     pm: 'evening',
     qpm: 'evening',
     'every evening': 'evening',
     'daily in evening': 'evening',
     'in evening': 'evening',
     'in the evening': 'evening',
+    'in the evenings': 'evening',
     'in the pm': 'evening',
     bedtime: 'bedtime',
     night: 'bedtime',
@@ -2335,6 +2337,10 @@ function freqNumeric(freqStr) {
     hs: 1,
     nightly: 1
   };
+
+  /* every N hours or N-M hours → treat first number as the interval */
+  const ev = f.match(/\bevery\s*(\d+)(?:\s*-\s*(\d+))?\s*hours?\b/i);
+  if (ev) return 24 / parseInt(ev[1], 10);
   const range = /^q(\d+)-(\d+)h$/i.exec(f);
   if (range) {
     const min = Number(range[1]);

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -54,6 +54,11 @@ describe('freqNumeric', () => {
     expect(ctx.freqNumeric('q12h')).toBe(2);
   });
 
+  test('"every 8 hours" evaluates to 3 times daily', () => {
+    const ctx = loadAppContext();
+    expect(ctx.freqNumeric('every 8 hours')).toBe(3);
+  });
+
   test('"q48h" evaluates to every other day', () => {
     const ctx = loadAppContext();
     expect(ctx.freqNumeric('q48h')).toBe(0.5);
@@ -116,6 +121,16 @@ describe('normalizeTimeOfDay', () => {
   test('"midday" normalizes to noon', () => {
     const ctx = loadAppContext();
     expect(ctx.normalizeTimeOfDay('midday')).toBe('noon');
+  });
+
+  test('plural evenings normalize to evening', () => {
+    const ctx = loadAppContext();
+    expect(ctx.normalizeTimeOfDay('evenings')).toBe('evening');
+  });
+
+  test('"in the evenings" normalizes to evening', () => {
+    const ctx = loadAppContext();
+    expect(ctx.normalizeTimeOfDay('in the evenings')).toBe('evening');
   });
 });
 


### PR DESCRIPTION
## Summary
- handle `evenings` and `in the evenings` in normalizeTimeOfDay
- support numeric `every N hours` patterns
- test evening normalization and every-hours numeric logic

## Testing
- `npm run lint`
- `npm test`
