### PR TITLE
Handle plural evening strings

### DIFF
--- a/index.html
+++ b/index.html
@@ -2198,12 +2198,14 @@ function normalizeTimeOfDay(t) {
     'in the morning': 'morning',
     'daily in morning': 'morning',
     evening: 'evening',
+    evenings: 'evening',
     pm: 'evening',
     qpm: 'evening',
     'every evening': 'evening',
     'daily in evening': 'evening',
     'in evening': 'evening',
     'in the evening': 'evening',
+    'in the evenings': 'evening',
     'in the pm': 'evening',
     bedtime: 'bedtime',
     night: 'bedtime',
@@ -2967,6 +2969,10 @@ if (
   normalizeFrequency(orig.frequency) === normalizeFrequency(updated.frequency) &&
   todChanged(orig, updated)
 ) {
+  freqChange = false;
+}
+// If the schedules are numerically the same, never call it a frequency change
+if (sameFrequency(orig.frequency, updated.frequency)) {
   freqChange = false;
 }
 if (freqChange) add('Frequency changed');

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -117,6 +117,16 @@ describe('normalizeTimeOfDay', () => {
     const ctx = loadAppContext();
     expect(ctx.normalizeTimeOfDay('midday')).toBe('noon');
   });
+
+  test('plural evenings normalize to evening', () => {
+    const ctx = loadAppContext();
+    expect(ctx.normalizeTimeOfDay('evenings')).toBe('evening');
+  });
+
+  test('"in the evenings" normalizes to evening', () => {
+    const ctx = loadAppContext();
+    expect(ctx.normalizeTimeOfDay('in the evenings')).toBe('evening');
+  });
 });
 
 describe('canonFormulation comparisons', () => {


### PR DESCRIPTION
## Summary
- handle `evenings` and `in the evenings` in normalizeTimeOfDay
- test evening normalization
- prevent bogus Frequency flag when TOD shifts

## Testing
- `npm test`
- `npm run lint`
