### PR TITLE
Handle plural evening strings

### DIFF
--- a/index.html
+++ b/index.html
@@ -2198,12 +2198,14 @@ function normalizeTimeOfDay(t) {
     'in the morning': 'morning',
     'daily in morning': 'morning',
     evening: 'evening',
+    evenings: 'evening',
     pm: 'evening',
     qpm: 'evening',
     'every evening': 'evening',
     'daily in evening': 'evening',
     'in evening': 'evening',
     'in the evening': 'evening',
+    'in the evenings': 'evening',
     'in the pm': 'evening',
     bedtime: 'bedtime',
     night: 'bedtime',
@@ -2947,6 +2949,12 @@ if (!freqSameNum) {
     freqChange = true;
   }
 } else if (
+  /* Only count a wording-only difference when *both* sides
+     actually specify a frequency string.  This prevents a
+     spurious "Frequency changed" when one side is blank
+     (implicitly daily) and the other says "daily in the evening". */
+  orig.frequency &&
+  updated.frequency &&
   normalizeFrequency(orig.frequency) !== normalizeFrequency(updated.frequency) &&
   todChanged(orig, updated)
 ) {

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -117,6 +117,16 @@ describe('normalizeTimeOfDay', () => {
     const ctx = loadAppContext();
     expect(ctx.normalizeTimeOfDay('midday')).toBe('noon');
   });
+
+  test('plural evenings normalize to evening', () => {
+    const ctx = loadAppContext();
+    expect(ctx.normalizeTimeOfDay('evenings')).toBe('evening');
+  });
+
+  test('"in the evenings" normalizes to evening', () => {
+    const ctx = loadAppContext();
+    expect(ctx.normalizeTimeOfDay('in the evenings')).toBe('evening');
+  });
 });
 
 describe('canonFormulation comparisons', () => {


### PR DESCRIPTION
## Summary
- handle `evenings` and `in the evenings` in normalizeTimeOfDay
- test evening normalization
- guard frequency wording-only difference if either side lacks frequency text

## Testing
- `npm test`
- `npm run lint`