### PR TITLE
Handle blank-vs-TOD frequency

### DIFF
--- a/index.html
+++ b/index.html
@@ -2198,12 +2198,14 @@ function normalizeTimeOfDay(t) {
     'in the morning': 'morning',
     'daily in morning': 'morning',
     evening: 'evening',
+    evenings: 'evening',
     pm: 'evening',
     qpm: 'evening',
     'every evening': 'evening',
     'daily in evening': 'evening',
     'in evening': 'evening',
     'in the evening': 'evening',
+    'in the evenings': 'evening',
     'in the pm': 'evening',
     bedtime: 'bedtime',
     night: 'bedtime',
@@ -2947,7 +2949,13 @@ if (!freqSameNum) {
     freqChange = true;
   }
 } else if (
-  normalizeFrequency(orig.frequency) !== normalizeFrequency(updated.frequency) &&
+  /* Skip wording-only frequency flags unless BOTH sides already
+     have a non-blank frequency string.  If either side is blank
+     (implicit daily) but the numeric schedules are equal, handle
+     it purely as a time-of-day shift. */
+  orig.frequency && updated.frequency &&
+  normalizeFrequency(orig.frequency) !==
+  normalizeFrequency(updated.frequency) &&
   todChanged(orig, updated)
 ) {
   freqChange = true;

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -117,6 +117,16 @@ describe('normalizeTimeOfDay', () => {
     const ctx = loadAppContext();
     expect(ctx.normalizeTimeOfDay('midday')).toBe('noon');
   });
+
+  test('plural evenings normalize to evening', () => {
+    const ctx = loadAppContext();
+    expect(ctx.normalizeTimeOfDay('evenings')).toBe('evening');
+  });
+
+  test('"in the evenings" normalizes to evening', () => {
+    const ctx = loadAppContext();
+    expect(ctx.normalizeTimeOfDay('in the evenings')).toBe('evening');
+  });
 });
 
 describe('canonFormulation comparisons', () => {


### PR DESCRIPTION
## Summary
- suppress wording-only frequency flag when one side is blank

## Testing
- `npm test`
