### PR TITLE
Fix indication change detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -2781,7 +2781,7 @@ function getChangeReason(orig, updated) {
   const prnMatch = same(orig.prn, updated.prn);
   const ind1 = normalizeIndication(orig.indication);
   const ind2 = normalizeIndication(updated.indication);
-  const indicationDiff = ind1 && ind2 && ind1 !== ind2;
+  const indicationDiff = ind1 !== ind2;
   if (indicationDiff) add('Indication changed');
   const startDateMatch = same(orig.startDate, updated.startDate);
   const endDateMatch = same(orig.endDate, updated.endDate);

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -10,7 +10,7 @@ describe('Medication comparison', () => {
     expect(result).toBe('Dose changed, Brand/Generic changed, Form changed');
   });
 
-  test('adding nerve pain indication ignored when original blank', () => {
+  test('adding nerve pain indication flagged when original blank', () => {
     const ctx = loadAppContext();
     const before = 'Gabapentin 300mg capsule - take 1 cap po tid';
     const after = 'Gabapentin 300mg capsule - take 1 cap po tid for nerve pain';
@@ -18,7 +18,7 @@ describe('Medication comparison', () => {
     const p2 = ctx.parseOrder(after);
     expect(p2.indication).toBe('neuropathy');
     const result = ctx.getChangeReason(p1, p2);
-    expect(result).toBe('Unchanged');
+    expect(result).toBe('Indication changed');
   });
 
   test('normalizeIndicationText maps wheezing', () => {


### PR DESCRIPTION
## Summary
- flag `Indication changed` when one order has an indication and the other does not
- update unit test for indication addition/removal

## Testing
- `npm run lint`
- `npm test`