### PR TITLE
Handle extra strength modifiers in med name normalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -1750,6 +1750,22 @@ function hasContra(orderObj, wholeList = []) {
     }
     n = n.replace(/\s+/g, ' ').trim();
 
+    // Remove common descriptive modifiers like "extra strength" or "pm"
+    const commonModifiers = [
+        'extra strength', 'regular strength', 'maximum strength',
+        'extra', 'regular', 'maximum',
+        'pm', 'am', 'advanced', 'complete',
+        'childrens', 'infants',
+        'arthritis pain', 'cold & flu', 'cold and flu', 'sinus', 'allergy',
+        'headache', 'migraine', 'multi symptom', 'daytime', 'nighttime'
+    ];
+    commonModifiers.sort((a, b) => b.length - a.length);
+    for (const modifier of commonModifiers) {
+        const modifierRegex = new RegExp(`\\b${modifier.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}\\b`, 'gi');
+        n = n.replace(modifierRegex, ' ');
+    }
+    n = n.replace(/\s+/g, ' ').trim();
+
     /* 3 .  Remove timing / meal phrases that sneak into the name */
     n = n.replace(/\b(?:\d+\s*(?:min(?:ute)?s?|hr|hrs?|hours?)\s*)?(?:at|before|after|with|without)\s+(?:breakfast|lunch|dinner|meal(?:s)?|night|bedtime|morning|evening)\b/ig, '')
          .trim();

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -428,6 +428,12 @@ addTest('Tabs vs no form equal', () => {
     .toBe('Dose changed, Brand/Generic changed, Quantity changed');
 });
 
+addTest('Tylenol Extra Strength vs acetaminophen brand flag', () => {
+  const before = 'Tylenol Extra Strength 500 mg tablet po daily';
+  const after = 'Acetaminophen 500 mg tablet po daily';
+  expect(diff(before, after)).toBe('Brand/Generic changed');
+});
+
 addTest('Metoprolol XL vs ER unchanged', () => {
   const before = 'Metoprolol XL 50 mg tab daily';
   const after  = 'Metoprolol Succinate ER 50 mg tab daily';


### PR DESCRIPTION
## Summary
- expand medication name normalization to strip modifiers such as "extra strength"
- test Tylenol Extra Strength vs plain acetaminophen

## Testing
- `npm test`
- `npm run lint`
