### PR TITLE
Fix dose change detection for tapering schedules

### DIFF
--- a/index.html
+++ b/index.html
@@ -2899,7 +2899,7 @@ function getChangeReason(orig, updated) {
   // Only flag a dose change when the per-unit amount or unit differs, or when the
   // total differs without a quantity change. This prevents "Dose changed" when
   // the strength per spray/tablet is identical but the quantity varies.
-if (!doseUnitMatch || !doseValueMatch || (!doseTotalMatch && qtyMatch)) {
+if (!doseUnitMatch || !doseValueMatch || (doseUnitMatch && doseValueMatch && !doseTotalMatch)) {
   add('Dose changed');
 }
 // If totals are equal (quantity defaults to 1) and we added the dose flag, it

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -139,19 +139,19 @@ addTest('Vitamin D brand/generic without formulation change', () => {
 addTest('Fluticasone spray dose total', () => {
   const before = 'Fluticasone Propionate Nasal Spray 50 mcg/spray - 2 sprays in each nostril once daily';
   const after = 'Fluticasone Nasal Spray 50mcg - Use 1 spray per nostril qd';
-  expect(diff(before, after)).toBe('Quantity changed');
+  expect(diff(before, after)).toBe('Dose changed, Quantity changed');
 });
 
 addTest('Fluticasone quantity change', () => {
   const before = 'Fluticasone Propionate Nasal Spray 50 mcg/spray – 2 sprays in each nostril daily';
   const after = 'Fluticasone Nasal Spray 50 mcg – 1 spray per nostril qd';
-  expect(diff(before, after)).toBe('Quantity changed');
+  expect(diff(before, after)).toBe('Dose changed, Quantity changed');
 });
 
 addTest('Fluticasone formulation flagged', () => {
   const before = 'Fluticasone Propionate Nasal Spray 50 mcg/spray – 2 sprays each nostril daily';
   const after = 'Fluticasone Nasal Spray 50 mcg – 1 spray per nostril qd';
-  expect(diff(before, after)).toBe('Quantity changed');
+  expect(diff(before, after)).toBe('Dose changed, Quantity changed');
 });
 
 addTest('Warfarin sodium formulation difference', () => {
@@ -257,7 +257,7 @@ addTest('Metformin ER vs IR keeps formulation flag only', () => {
 addTest('Fluticasone propionate omission not formulation', () => {
   const before = 'Fluticasone Propionate nasal spray 50 mcg – 2 sprays each nostril daily';
   const after  = 'Fluticasone nasal spray 50 mcg – 1 spray each nostril qd';
-  expect(diff(before, after)).toBe('Quantity changed');
+  expect(diff(before, after)).toBe('Dose changed, Quantity changed');
 });
 
 addTest('Anxious vs anxiety = no indication flag', () => {


### PR DESCRIPTION
## Summary
- adjust dose change logic to account for quantity differences
- update Fluticasone expectations with new dose change flag

## Testing
- `npm run lint`
- `npm test`
