### PR TITLE
Preserve mild pain distinction

### DIFF
--- a/index.html
+++ b/index.html
@@ -2170,8 +2170,17 @@ function normalizeIndicationText(txt = '') {
 function normalizeIndication(txt) {
   if (!txt) return '';
 
+  txt = txt.toLowerCase();
+
+  const painDescriptors = ['mild pain', 'moderate pain', 'severe pain'];
+  const tokens = {};
+  painDescriptors.forEach(desc => {
+    const token = `_pain_${desc.replace(/\s+/g, '_')}_`;
+    tokens[desc] = token;
+    txt = txt.replace(new RegExp(`\\b${desc}\\b`, 'g'), token);
+  });
+
   txt = txt
-    .toLowerCase()
     .replace(/\b(type\s*2\s*)?diabetes\b/g, 'diabetes')
     .replace(/\b(htn|hypertension|high blood pressure)\b/g, 'hypertension')
     .replace(/\bhigh cholesterol\b/g, 'cholesterol')
@@ -2212,6 +2221,10 @@ function normalizeIndication(txt) {
   }
 
   txt = processedTxt;
+
+  Object.entries(tokens).forEach(([desc, token]) => {
+    txt = txt.replace(new RegExp(token, 'g'), desc);
+  });
 
   return txt.replace(/\s+/g, ' ').trim();
 }

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -101,6 +101,14 @@ describe('Medication comparison', () => {
     expect(result).toBe('Indication changed');
   });
 
+  test('mild pain vs pain flagged', () => {
+    const ctx = loadAppContext();
+    const before = ctx.parseOrder('Acetaminophen 500 mg tab q6h prn pain');
+    const after = ctx.parseOrder('Acetaminophen 500 mg tab q6h prn mild pain');
+    const result = ctx.getChangeReason(before, after);
+    expect(result).toBe('Indication changed');
+  });
+
   test('fraction unicode quantity parsed', () => {
     const ctx = loadAppContext();
     const order = ctx.parseOrder('Aspirin \u00bd tab daily');


### PR DESCRIPTION
## Summary
- keep specific pain descriptors like "mild pain" intact when normalizing indications
- add unit test covering mild pain vs pain

## Testing
- `npm test`