### PR TITLE
Fix indication normalization for pain descriptors

### DIFF
--- a/index.html
+++ b/index.html
@@ -2170,17 +2170,17 @@ function normalizeIndicationText(txt = '') {
 function normalizeIndication(txt) {
   if (!txt) return '';
 
-  txt = txt.toLowerCase();
+  let s = txt.toLowerCase().replace(/[.;,]+/g, ' ').trim();
 
   const painDescriptors = ['mild pain', 'moderate pain', 'severe pain'];
   const tokens = {};
   painDescriptors.forEach(desc => {
     const token = `_pain_${desc.replace(/\s+/g, '_')}_`;
-    tokens[desc] = token;
-    txt = txt.replace(new RegExp(`\\b${desc}\\b`, 'g'), token);
+    tokens[token] = desc;
+    s = s.replace(new RegExp(`\\b${desc}\\b`, 'g'), token);
   });
 
-  txt = txt
+  s = s
     .replace(/\b(type\s*2\s*)?diabetes\b/g, 'diabetes')
     .replace(/\b(htn|hypertension|high blood pressure)\b/g, 'hypertension')
     .replace(/\bhigh cholesterol\b/g, 'cholesterol')
@@ -2189,14 +2189,14 @@ function normalizeIndication(txt) {
     .replace(/\bas needed\b/g, 'prn')
     .replace(/\bfor sleep\b/i, 'sleep');
 
-  txt = txt
+  s = s
     .replace(/\banticoag(ulation)? clinic\b/gi, '')
     .replace(/\binr\s*\d+(?:\.\d+)?\s*-\s*\d+(?:\.\d+)?\b/gi, '')
     .replace(/\b(no\s+)?taper\b/gi, '');
 
   const fillerRE =
     /\b(?:po|by mouth|orally|tablet?s?|tab|daily|every day|in evening|evening|at bedtime|morning|stop|no taper|taper|for \d+\s*days?)\b/gi;
-  txt = txt
+  s = s
     .replace(fillerRE, ' ')
     .replace(/\s+/g, ' ')
     .trim();
@@ -2207,10 +2207,10 @@ function normalizeIndication(txt) {
     'nerve pain': 'neuropathy',
     neuropathy: 'neuropathy'
   };
-  if (synonyms[txt]) txt = synonyms[txt];
+  if (synonyms[s]) s = synonyms[s];
 
   // Map common INR monitoring instructions to unique tokens
-  let processedTxt = txt.toLowerCase();
+  let processedTxt = s.toLowerCase();
   if (/\badjust\s+(?:per\s+)?inr\b/.test(processedTxt)) {
     processedTxt = processedTxt.replace(/\badjust\s+(?:per\s+)?inr\b/g, '_unique_inr_adjust_protocol_');
   }
@@ -2220,13 +2220,13 @@ function normalizeIndication(txt) {
     processedTxt = processedTxt.replace(/\bcheck\s+inr\b/g, '_unique_inr_check_protocol_');
   }
 
-  txt = processedTxt;
+  s = processedTxt;
 
-  Object.entries(tokens).forEach(([desc, token]) => {
-    txt = txt.replace(new RegExp(token, 'g'), desc);
+  Object.entries(tokens).forEach(([token, desc]) => {
+    s = s.replace(new RegExp(token, 'g'), desc);
   });
 
-  return txt.replace(/\s+/g, ' ').trim();
+  return s.replace(/\s+/g, ' ').trim();
 }
 
 function normalizeTimeOfDay(t) {


### PR DESCRIPTION
## Summary
- keep "pain" distinct from "mild pain" when normalizing indications
- ensure general rules don't collapse specific pain descriptors

## Testing
- `npm test`
- `npm run lint`