### PR TITLE
Fix header scaling on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       background-color: #007bff;
       color: white;
       text-align: center;
-      padding: 8px 15px 12px 15px;
+      padding: 10px 15px;
       position: sticky;
       top: 0;
       z-index: 1000;
@@ -40,7 +40,10 @@
 
     @media (max-width: 600px) {
       header {
-        height: 100px;
+        height: 110px;
+      }
+      #medrec-logo {
+        height: 45px;
       }
     }
     main {
@@ -395,11 +398,12 @@ table.changes-table th {
       opacity: 1;
     }
     #medrec-logo {
-      height: 60px;
-      width: auto;
       display: block;
-      margin: 0 auto;
-      margin-bottom: 8px;
+      width: auto;
+      margin-left: auto;
+      margin-right: auto;
+      margin-bottom: 10px;
+      height: 55px;
     }
     /* New styles for text input */
     .text-input-container {


### PR DESCRIPTION
## Summary
- tweak header layout to size well on desktop and mobile
- center logo with flexible height
- remove extra space around progress bar

## Testing
- `npm test`
- `npm run lint`
