### PR TITLE
Fix formulation change detection for salts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1754,7 +1754,7 @@ function hasContra(orderObj, wholeList = []) {
 
 
   const ignoreSalts = /\b(hydrochloride|sulfate|phosphate|acetate|carbonate|maleate|succinate|tartrate|mesylate|besylate|camsylate|gluconate|bitartrate|edisylate|propionate|sodium|potassium|calcium|magnesium|fumarate)\b/gi;
-  const trivialSalts = /\b(sodium|hydrochloride|sulfate|phosphate|acetate|carbonate|succinate|maleate|tartrate|mesylate|besylate|camsylate|gluconate|bitartrate|edisylate|propionate|potassium|calcium|magnesium|fumarate)\b/gi;
+  const trivialSalts = /\b(sulfate|phosphate|acetate|carbonate|succinate|maleate|tartrate|mesylate|besylate|camsylate|gluconate|bitartrate|edisylate|calcium|magnesium|fumarate)\b/gi;
 
   const importantSaltPairs = [
     ['diclofenac sodium',      'diclofenac potassium'],

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -228,4 +228,28 @@ describe('Medication comparison', () => {
       throw new Error('Route flag set for inhaler brand swap: ' + result);
     }
   });
+
+  test('Warfarin sodium vs warfarin flags formulation', () => {
+    const ctx = loadAppContext();
+    const before = ctx.parseOrder('Warfarin sodium 5 mg tablet - one po qPM for atrial fibrillation. Start date: 01/01/2025');
+    const after = ctx.parseOrder('Warfarin 5 mg tablet - 1 PO daily in evening for afib. Start date: 01/01/2025');
+    const result = ctx.getChangeReason(before, after);
+    expect(result).toMatch(/Formulation changed/);
+  });
+
+  test('Metformin HCl ER vs Metformin ER flags formulation', () => {
+    const ctx = loadAppContext();
+    const before = ctx.parseOrder('Metformin hydrochloride 1000mg ER - Take one tablet by mouth every evening with supper');
+    const after = ctx.parseOrder('Metformin ER 1000mg - Take 1 tab po nightly with food');
+    const result = ctx.getChangeReason(before, after);
+    expect(result).toMatch(/Formulation changed/);
+  });
+
+  test('Fluticasone propionate omission flags formulation', () => {
+    const ctx = loadAppContext();
+    const before = ctx.parseOrder('Fluticasone Propionate Nasal Spray 50 mcg/spray - 2 sprays in each nostril once daily');
+    const after = ctx.parseOrder('Fluticasone Nasal Spray 50mcg - Use 1 spray per nostril qd');
+    const result = ctx.getChangeReason(before, after);
+    expect(result).toMatch(/Formulation changed/);
+  });
 });

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -139,25 +139,25 @@ addTest('Vitamin D brand/generic without formulation change', () => {
 addTest('Fluticasone spray dose total', () => {
   const before = 'Fluticasone Propionate Nasal Spray 50 mcg/spray - 2 sprays in each nostril once daily';
   const after = 'Fluticasone Nasal Spray 50mcg - Use 1 spray per nostril qd';
-  expect(diff(before, after)).toBe('Dose changed, Quantity changed');
+  expect(diff(before, after)).toBe('Dose changed, Formulation changed, Quantity changed');
 });
 
 addTest('Fluticasone quantity change', () => {
   const before = 'Fluticasone Propionate Nasal Spray 50 mcg/spray – 2 sprays in each nostril daily';
   const after = 'Fluticasone Nasal Spray 50 mcg – 1 spray per nostril qd';
-  expect(diff(before, after)).toBe('Dose changed, Quantity changed');
+  expect(diff(before, after)).toBe('Dose changed, Formulation changed, Quantity changed');
 });
 
 addTest('Fluticasone formulation flagged', () => {
   const before = 'Fluticasone Propionate Nasal Spray 50 mcg/spray – 2 sprays each nostril daily';
   const after = 'Fluticasone Nasal Spray 50 mcg – 1 spray per nostril qd';
-  expect(diff(before, after)).toBe('Dose changed, Quantity changed');
+  expect(diff(before, after)).toBe('Dose changed, Formulation changed, Quantity changed');
 });
 
 addTest('Warfarin sodium formulation difference', () => {
   const before = 'Warfarin sodium 5 mg tablet - take one daily';
   const after = 'Warfarin 5 mg tablet - take one daily';
-  expect(diff(before, after)).toBe('');
+  expect(diff(before, after)).toBe('Formulation changed');
 });
 
 addTest('Warfarin qPM vs evening flagged', () => {
@@ -239,13 +239,13 @@ addTest('Diclofenac sodium vs potassium flags formulation', () => {
 addTest('Warfarin sodium vs warfarin unchanged', () => {
   const before = 'Warfarin sodium 5 mg tablet po evening';
   const after  = 'Warfarin 5 mg tablet po qpm';
-  expect(diff(before, after)).toBe('');
+  expect(diff(before, after)).toBe('Formulation changed');
 });
 
 addTest('Metformin HCl ER vs Metformin ER unchanged', () => {
   const b = 'Metformin hydrochloride 1000 mg ER tablet nightly';
   const a = 'Metformin ER 1000 mg tablet evening';
-  expect(diff(b, a)).toBe('Time of day changed');
+  expect(diff(b, a)).toBe('Formulation changed, Time of day changed');
 });
 
 addTest('Metformin ER vs IR keeps formulation flag only', () => {
@@ -257,7 +257,7 @@ addTest('Metformin ER vs IR keeps formulation flag only', () => {
 addTest('Fluticasone propionate omission not formulation', () => {
   const before = 'Fluticasone Propionate nasal spray 50 mcg – 2 sprays each nostril daily';
   const after  = 'Fluticasone nasal spray 50 mcg – 1 spray each nostril qd';
-  expect(diff(before, after)).toBe('Dose changed, Quantity changed');
+  expect(diff(before, after)).toBe('Dose changed, Formulation changed, Quantity changed');
 });
 
 addTest('Anxious vs anxiety = no indication flag', () => {
@@ -582,7 +582,7 @@ addTest('Iron vs Ferrous frequency change only', () => {
 addTest('Synthroid brand + AM equal', () => {
   const before = 'Levothyroxine sodium 100 mcg qam';
   const after  = 'Synthroid 100 mcg every morning';
-  expect(diff(before, after)).toBe('Brand/Generic changed');
+  expect(diff(before, after)).toBe('Formulation changed, Brand/Generic changed');
 });
 
 addTest('Coumadin brand, INR text equal, dose diff', () => {
@@ -600,7 +600,7 @@ addTest('Pred taper wording ignored', () => {
 addTest('Vancomycin generic vs hydrochloride unchanged', () => {
   const before = 'Vancomycin 1 g q12h';
   const after  = 'Vancomycin hydrochloride 1 gram q12h';
-  expect(diff(before, after)).toBe('');
+  expect(diff(before, after)).toBe('Formulation changed');
 });
 
 addTest('Coumadin brand vs warfarin regimen only', () => {
@@ -675,7 +675,7 @@ addTest('Vancomycin monitoring wording', () => {
   expect(diff(
     'Vancomycin 1 g q12h – trough before 4th dose',
     'Vancomycin hydrochloride 1 g q12h – target trough 15-20 mcg/mL'))
-    .toBe('Indication changed');
+    .toBe('Formulation changed, Indication changed');
 });
 addTest('Warfarin brand with INR & schedule words – indication equal', () => {
   const a = 'Warfarin 3mg MWF 3mg TTSu 1.5mg INR 2-3 PO evening';
@@ -884,8 +884,8 @@ addTest('Warfarin sodium vs warfarin direct comparison', () => {
   const before = 'Warfarin sodium 5 mg tablet po evening';
   const after = 'Warfarin 5 mg tablet po qpm';
   const reason = ctx.getChangeReason(ctx.parseOrder(before), ctx.parseOrder(after));
-  if (reason.includes('Formulation changed')) {
-    throw new Error('Unexpected formulation flag: ' + reason);
+  if (!reason.includes('Formulation changed')) {
+    throw new Error('Expected formulation flag missing: ' + reason);
   }
 });
 


### PR DESCRIPTION
## Summary
- treat sodium, hydrochloride and related terms as significant formulation words
- expect formulation change flags for salt/ester differences in tests
- add regression tests for warfarin sodium, metformin HCl, and fluticasone propionate cases

## Testing
- `npm test`