### PR TITLE
Fix combo dose change detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -2999,11 +2999,24 @@ function getChangeReason(orig, updated) {
   // Only flag a dose change when the per-unit amount or unit differs, or when the
   // total differs without a quantity change. This prevents "Dose changed" when
   // the strength per spray/tablet is identical but the quantity varies.
-if (!doseUnitMatch || !doseValueMatch || (doseUnitMatch && doseValueMatch && !doseTotalMatch)) {
-  add('Dose changed');
-}
-// If totals are equal (quantity defaults to 1) and we added the dose flag, it
-// likely came from a frequency-only change, so remove it.
+
+  let actualDoseDifference = false;
+  if (!doseUnitMatch || !doseValueMatch) {
+    actualDoseDifference = true;
+  } else {
+    if (Array.isArray(orig.dose?.value)) {
+      if (!qtyMatch) actualDoseDifference = true;
+    } else if (!doseTotalMatch) {
+      actualDoseDifference = true;
+    }
+  }
+
+  if (actualDoseDifference) {
+    add('Dose changed');
+  }
+
+  // If totals are equal (quantity defaults to 1) and we added the dose flag, it
+  // likely came from a frequency-only change, so remove it.
 const sameStrength =
   doseValueMatch &&
   doseUnitMatch &&

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -252,4 +252,12 @@ describe('Medication comparison', () => {
     const result = ctx.getChangeReason(before, after);
     expect(result).toMatch(/Formulation changed/);
   });
+
+  test('Lisinopril/HCTZ combo dose should not flag dose change if components and qty are same', () => {
+    const ctx = loadAppContext();
+    const before = ctx.parseOrder('Lisinopril/HCTZ 20-12.5mg - 1 tab daily');
+    const after = ctx.parseOrder('Lisinopril 20mg / Hydrochlorothiazide 12.5mg combination tablet - 1 tablet PO daily');
+    const result = ctx.getChangeReason(before, after);
+    expect(result.includes('Dose changed')).toBe(false);
+  });
 });

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -215,7 +215,7 @@ addTest('Spiriva brand/generic flag', () => {
 addTest('HCTZ abbreviation no brand flag', () => {
   const before = 'Lisinopril/HCTZ 20-12.5mg PO daily';
   const after  = 'Lisinopril 20mg / Hydrochlorothiazide 12.5mg PO daily';
-  expect(diff(before, after)).toBe('Dose changed, Brand/Generic changed');
+  expect(diff(before, after)).toBe('Brand/Generic changed');
 });
 
 addTest('Insulin TIDAC equals before meals (no freq flag)', () => {


### PR DESCRIPTION
## Summary
- update dose change logic so combination products with identical component doses don't trigger a `Dose changed` flag
- adjust regression test expectation for lisinopril/HCTZ combo
- add new unit test for combination dose case

## Testing
- `npm test`