### PR TITLE
Fix trivial salt handling and AFib indication

### DIFF
--- a/index.html
+++ b/index.html
@@ -1754,7 +1754,7 @@ function hasContra(orderObj, wholeList = []) {
 
 
   const ignoreSalts = /\b(hydrochloride|sulfate|phosphate|acetate|carbonate|maleate|succinate|tartrate|mesylate|besylate|camsylate|gluconate|bitartrate|edisylate|propionate|sodium|potassium|calcium|magnesium|fumarate)\b/gi;
-  const trivialSalts = /\b(sulfate|phosphate|acetate|carbonate|succinate|maleate|tartrate|mesylate|besylate|camsylate|gluconate|bitartrate|edisylate|calcium|magnesium|fumarate)\b/gi;
+  const trivialSalts = /\b(sodium|sulfate|phosphate|acetate|carbonate|succinate|maleate|tartrate|mesylate|besylate|camsylate|gluconate|bitartrate|edisylate|calcium|magnesium|fumarate)\b/gi;
 
   const importantSaltPairs = [
     ['diclofenac sodium',      'diclofenac potassium'],
@@ -2243,7 +2243,10 @@ function normalizeIndicationText(txt = '') {
 function normalizeIndication(txt) {
   if (!txt) return '';
 
-  txt = txt.toLowerCase();
+  txt = txt
+    .toLowerCase()
+    .replace(/[.;,]+/g, ' ')
+    .replace(/\bstart\s*date.*$/i, '');
 
   const painDescriptors = ['mild pain', 'moderate pain', 'severe pain'];
   const tokens = {};
@@ -2278,7 +2281,11 @@ function normalizeIndication(txt) {
     sob: 'breathing difficulty',
     wheezing: 'breathing difficulty',
     'nerve pain': 'neuropathy',
-    neuropathy: 'neuropathy'
+    neuropathy: 'neuropathy',
+    afib: 'atrial fibrillation',
+    af: 'atrial fibrillation',
+    'a fib': 'atrial fibrillation',
+    'atrial fib': 'atrial fibrillation'
   };
   if (synonyms[txt]) txt = synonyms[txt];
 

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -53,7 +53,7 @@ describe('Medication comparison', () => {
     const p1 = ctx.parseOrder(before);
   const p2 = ctx.parseOrder(after);
   const result = ctx.getChangeReason(p1, p2);
-  expect(result).toBe('Indication changed');
+  expect(result).toBe('Unchanged');
 });
 
   test('taper wording ignored in indications', () => {
@@ -229,12 +229,12 @@ describe('Medication comparison', () => {
     }
   });
 
-  test('Warfarin sodium vs warfarin flags formulation', () => {
+  test('Warfarin sodium vs warfarin time shift only', () => {
     const ctx = loadAppContext();
     const before = ctx.parseOrder('Warfarin sodium 5 mg tablet - one po qPM for atrial fibrillation. Start date: 01/01/2025');
     const after = ctx.parseOrder('Warfarin 5 mg tablet - 1 PO daily in evening for afib. Start date: 01/01/2025');
     const result = ctx.getChangeReason(before, after);
-    expect(result).toMatch(/Formulation changed/);
+    expect(result).toBe('Unchanged');
   });
 
   test('Metformin HCl ER vs Metformin ER flags formulation', () => {

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -157,7 +157,7 @@ addTest('Fluticasone formulation flagged', () => {
 addTest('Warfarin sodium formulation difference', () => {
   const before = 'Warfarin sodium 5 mg tablet - take one daily';
   const after = 'Warfarin 5 mg tablet - take one daily';
-  expect(diff(before, after)).toBe('Formulation changed');
+  expect(diff(before, after)).toBe('');
 });
 
 addTest('Warfarin qPM vs evening flagged', () => {
@@ -201,7 +201,7 @@ addTest('Clonidine enumerate changes', () => {
 addTest('AF abbreviation normalized', () => {
   const before = 'Metoprolol 50 mg tablet - take 1 tab daily for af';
   const after = 'Metoprolol 50 mg tablet - take 1 tab daily for atrial fibrillation';
-  expect(diff(before, after)).toBe('Indication changed');
+  expect(diff(before, after)).toBe('');
 });
 
 addTest('Spiriva brand/generic flag', () => {
@@ -239,7 +239,7 @@ addTest('Diclofenac sodium vs potassium flags formulation', () => {
 addTest('Warfarin sodium vs warfarin unchanged', () => {
   const before = 'Warfarin sodium 5 mg tablet po evening';
   const after  = 'Warfarin 5 mg tablet po qpm';
-  expect(diff(before, after)).toBe('Formulation changed');
+  expect(diff(before, after)).toBe('');
 });
 
 addTest('Metformin HCl ER vs Metformin ER unchanged', () => {
@@ -582,7 +582,7 @@ addTest('Iron vs Ferrous frequency change only', () => {
 addTest('Synthroid brand + AM equal', () => {
   const before = 'Levothyroxine sodium 100 mcg qam';
   const after  = 'Synthroid 100 mcg every morning';
-  expect(diff(before, after)).toBe('Formulation changed, Brand/Generic changed');
+  expect(diff(before, after)).toBe('Brand/Generic changed');
 });
 
 addTest('Coumadin brand, INR text equal, dose diff', () => {
@@ -884,8 +884,8 @@ addTest('Warfarin sodium vs warfarin direct comparison', () => {
   const before = 'Warfarin sodium 5 mg tablet po evening';
   const after = 'Warfarin 5 mg tablet po qpm';
   const reason = ctx.getChangeReason(ctx.parseOrder(before), ctx.parseOrder(after));
-  if (!reason.includes('Formulation changed')) {
-    throw new Error('Expected formulation flag missing: ' + reason);
+  if (reason.includes('Formulation changed')) {
+    throw new Error('Unexpected formulation flag: ' + reason);
   }
 });
 


### PR DESCRIPTION
## Summary
- ignore `sodium` when comparing formulations
- normalize AFib synonyms in `normalizeIndication`
- strip trailing "start date" text when normalizing indications
- update Warfarin comparison tests
- update AF abbreviation and Synthroid expectations

## Testing
- `npm test`