### PR TITLE
Handle hydrochloride as trivial salt

### DIFF
--- a/index.html
+++ b/index.html
@@ -1754,7 +1754,7 @@ function hasContra(orderObj, wholeList = []) {
 
 
   const ignoreSalts = /\b(hydrochloride|sulfate|phosphate|acetate|carbonate|maleate|succinate|tartrate|mesylate|besylate|camsylate|gluconate|bitartrate|edisylate|propionate|sodium|potassium|calcium|magnesium|fumarate)\b/gi;
-  const trivialSalts = /\b(sodium|sulfate|phosphate|acetate|carbonate|succinate|maleate|tartrate|mesylate|besylate|camsylate|gluconate|bitartrate|edisylate|calcium|magnesium|fumarate)\b/gi;
+  const trivialSalts = /\b(sodium|sulfate|phosphate|acetate|carbonate|succinate|maleate|tartrate|mesylate|besylate|camsylate|gluconate|bitartrate|edisylate|calcium|magnesium|fumarate|hydrochloride)\b/gi;
 
   const importantSaltPairs = [
     ['diclofenac sodium',      'diclofenac potassium'],

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -242,7 +242,7 @@ describe('Medication comparison', () => {
     const before = ctx.parseOrder('Metformin hydrochloride 1000mg ER - Take one tablet by mouth every evening with supper');
     const after = ctx.parseOrder('Metformin ER 1000mg - Take 1 tab po nightly with food');
     const result = ctx.getChangeReason(before, after);
-    expect(result).toMatch(/Formulation changed/);
+    expect(result).toBe('Time of day changed, Administration changed');
   });
 
   test('Fluticasone propionate omission flags formulation', () => {

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -245,7 +245,7 @@ addTest('Warfarin sodium vs warfarin unchanged', () => {
 addTest('Metformin HCl ER vs Metformin ER unchanged', () => {
   const b = 'Metformin hydrochloride 1000 mg ER tablet nightly';
   const a = 'Metformin ER 1000 mg tablet evening';
-  expect(diff(b, a)).toBe('Formulation changed, Time of day changed');
+  expect(diff(b, a)).toBe('Time of day changed');
 });
 
 addTest('Metformin ER vs IR keeps formulation flag only', () => {
@@ -600,7 +600,7 @@ addTest('Pred taper wording ignored', () => {
 addTest('Vancomycin generic vs hydrochloride unchanged', () => {
   const before = 'Vancomycin 1 g q12h';
   const after  = 'Vancomycin hydrochloride 1 gram q12h';
-  expect(diff(before, after)).toBe('Formulation changed');
+  expect(diff(before, after)).toBe('');
 });
 
 addTest('Coumadin brand vs warfarin regimen only', () => {
@@ -675,7 +675,7 @@ addTest('Vancomycin monitoring wording', () => {
   expect(diff(
     'Vancomycin 1 g q12h – trough before 4th dose',
     'Vancomycin hydrochloride 1 g q12h – target trough 15-20 mcg/mL'))
-    .toBe('Formulation changed, Indication changed');
+    .toBe('Indication changed');
 });
 addTest('Warfarin brand with INR & schedule words – indication equal', () => {
   const a = 'Warfarin 3mg MWF 3mg TTSu 1.5mg INR 2-3 PO evening';


### PR DESCRIPTION
## Summary
- treat `hydrochloride` as a trivial salt in `index.html`
- update tests expecting formulation changes when hydrochloride present

## Testing
- `npm test`
- `npm run lint`