### PR TITLE
Update evening mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -2311,36 +2311,36 @@ function normalizeIndication(txt) {
 
 function normalizeTimeOfDay(t) {
   if (!t) return '';
-  const aliases = {
-    morning: 'morning',
-    qam: 'morning',
-    am: 'morning',
-    'every am': 'morning',
-    'every morning': 'morning',
-    'in morning': 'morning',
-    'in the morning': 'morning',
-    'daily in morning': 'morning',
-    evening: 'evening',
-    evenings: 'evening',
-    pm: 'evening',
-    qpm: 'evening',
-    'every evening': 'evening',
-    'daily in evening': 'evening',
-    'in evening': 'evening',
-    'in the evening': 'evening',
-    'in the evenings': 'evening',
-    'in the pm': 'evening',
-    bedtime: 'bedtime',
-    night: 'bedtime',
-    qhs: 'bedtime',
-    nightly: 'bedtime',
-    'at bedtime': 'bedtime',
-    'at night': 'bedtime',
-    'every night': 'bedtime',
-    noon: 'noon',
-    'midday': 'noon',
-    'at noon': 'noon'
-  };
+    const aliases = {
+      morning: 'morning',
+      qam: 'morning',
+      am: 'morning',
+      'every am': 'morning',
+      'every morning': 'morning',
+      'in morning': 'morning',
+      'in the morning': 'morning',
+      'daily in morning': 'morning',
+      evening: 'bedtime',
+      evenings: 'bedtime',
+      pm: 'bedtime',
+      qpm: 'bedtime',
+      'every evening': 'bedtime',
+      'daily in evening': 'bedtime',
+      'in evening': 'bedtime',
+      'in the evening': 'bedtime',
+      'in the evenings': 'bedtime',
+      'in the pm': 'bedtime',
+      bedtime: 'bedtime',
+      night: 'bedtime',
+      qhs: 'bedtime',
+      nightly: 'bedtime',
+      'at bedtime': 'bedtime',
+      'at night': 'bedtime',
+      'every night': 'bedtime',
+      noon: 'noon',
+      midday: 'noon',
+      'at noon': 'noon'
+    };
   t = t.toLowerCase().trim();
   if (aliases[t]) return aliases[t];
   for (const key in aliases) {

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -100,7 +100,7 @@ describe('todChanged', () => {
     const ctx = loadAppContext();
     const a = { frequency: 'pm' };
     const b = { frequency: 'nightly' };
-    expect(ctx.todChanged(a, b)).toBe(true);
+    expect(ctx.todChanged(a, b)).toBe(false);
   });
 
   test('equivalent times of day not flagged', () => {
@@ -143,14 +143,14 @@ describe('normalizeTimeOfDay', () => {
     expect(ctx.normalizeTimeOfDay('midday')).toBe('noon');
   });
 
-  test('plural evenings normalize to evening', () => {
+  test('plural evenings normalize to bedtime', () => {
     const ctx = loadAppContext();
-    expect(ctx.normalizeTimeOfDay('evenings')).toBe('evening');
+    expect(ctx.normalizeTimeOfDay('evenings')).toBe('bedtime');
   });
 
-  test('"in the evenings" normalizes to evening', () => {
+  test('"in the evenings" normalizes to bedtime', () => {
     const ctx = loadAppContext();
-    expect(ctx.normalizeTimeOfDay('in the evenings')).toBe('evening');
+    expect(ctx.normalizeTimeOfDay('in the evenings')).toBe('bedtime');
   });
 });
 

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -242,7 +242,7 @@ describe('Medication comparison', () => {
     const before = ctx.parseOrder('Metformin hydrochloride 1000mg ER - Take one tablet by mouth every evening with supper');
     const after = ctx.parseOrder('Metformin ER 1000mg - Take 1 tab po nightly with food');
     const result = ctx.getChangeReason(before, after);
-    expect(result).toBe('Time of day changed, Administration changed');
+    expect(result).toBe('Administration changed');
   });
 
   test('Fluticasone propionate omission flags formulation', () => {

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -245,7 +245,7 @@ addTest('Warfarin sodium vs warfarin unchanged', () => {
 addTest('Metformin HCl ER vs Metformin ER unchanged', () => {
   const b = 'Metformin hydrochloride 1000 mg ER tablet nightly';
   const a = 'Metformin ER 1000 mg tablet evening';
-  expect(diff(b, a)).toBe('Time of day changed');
+  expect(diff(b, a)).toBe('');
 });
 
 addTest('Metformin ER vs IR keeps formulation flag only', () => {
@@ -758,7 +758,7 @@ addTest('Iron elemental parentheses no dose diff', () => {
 addTest('Warfarin fraction vs mg strength', () => {
   const before = 'Warfarin 1.5 mg evening';
   const after = 'Coumadin 1.5 mg nightly';
-  expect(diff(before, after)).toBe('Brand/Generic changed, Time of day changed');
+  expect(diff(before, after)).toBe('Brand/Generic changed');
 });
 
 addTest('Iron admin change flagged', () => {
@@ -770,7 +770,7 @@ addTest('Iron admin change flagged', () => {
 addTest('Warfarin tabs regimen diff only brand/time', () => {
   const before = 'Warfarin 3 mg tabs: 1 tab M/W/F 3 mg; Tu/Th/Sa/Su 1.5 mg evening';
   const after = 'Coumadin 3 mg tabs: 1 tab M/W/F 3 mg; Tu/Th/Sa/Su 1.5 mg nightly';
-  expect(diff(before, after)).toBe('Brand/Generic changed, Time of day changed');
+  expect(diff(before, after)).toBe('Brand/Generic changed');
 });
 
 addTest('Numeric frequency two times a day flagged', () => {


### PR DESCRIPTION
## Summary
- consolidate all evening aliases to `bedtime`
- expect time-of-day equivalence for pm/nightly
- adjust test expectations

## Testing
- `npm test`