### PR TITLE
Handle dinner/supper administration

### DIFF
--- a/index.html
+++ b/index.html
@@ -2538,7 +2538,7 @@ function canonFormulation(f) {
 function normalizeAdministration(str) {
   if (!str) return '';
   str = str.toLowerCase().replace(/\s+/g, ' ').trim();
-  if (/\bwith\s+(orange\s*juice|food|meal)s?\b/.test(str)) {
+  if (/\bwith\s+(?:orange\s*juice|food|meals?|dinner|supper)\b/.test(str)) {
     return 'with food';
   }
   if (/\b(between\s+meals|without\s+(food|meal)s?|empty\s*stomach)\b/.test(str)) {

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -242,7 +242,7 @@ describe('Medication comparison', () => {
     const before = ctx.parseOrder('Metformin hydrochloride 1000mg ER - Take one tablet by mouth every evening with supper');
     const after = ctx.parseOrder('Metformin ER 1000mg - Take 1 tab po nightly with food');
     const result = ctx.getChangeReason(before, after);
-    expect(result).toBe('Administration changed');
+    expect(result).toBe('Unchanged');
   });
 
   test('Fluticasone propionate omission flags formulation', () => {

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -375,6 +375,9 @@ addTest('normalizeAdministration canonical forms', () => {
   vm.createContext(ctx);
   vm.runInContext(script, ctx);
   expect(ctx.normalizeAdministration('with orange juice')).toBe('with food');
+  expect(ctx.normalizeAdministration('with supper')).toBe('with food');
+  expect(ctx.normalizeAdministration('with dinner')).toBe('with food');
+  expect(ctx.normalizeAdministration('with meals')).toBe('with food');
   expect(ctx.normalizeAdministration('empty stomach')).toBe('between meals');
 });
 


### PR DESCRIPTION
## Summary
- normalize 'with supper', 'with dinner' and 'with meals' to `with food`
- align expectations in administration comparison tests
- cover new administration forms in unit tests

## Testing
- `npm test`