### PR TITLE
Ignore propionate as formulation change

### DIFF
--- a/index.html
+++ b/index.html
@@ -1754,7 +1754,7 @@ function hasContra(orderObj, wholeList = []) {
 
 
   const ignoreSalts = /\b(hydrochloride|sulfate|phosphate|acetate|carbonate|maleate|succinate|tartrate|mesylate|besylate|camsylate|gluconate|bitartrate|edisylate|propionate|sodium|potassium|calcium|magnesium|fumarate)\b/gi;
-  const trivialSalts = /\b(sodium|sulfate|phosphate|acetate|carbonate|succinate|maleate|tartrate|mesylate|besylate|camsylate|gluconate|bitartrate|edisylate|calcium|magnesium|fumarate|hydrochloride)\b/gi;
+  const trivialSalts = /\b(sodium|sulfate|phosphate|acetate|carbonate|succinate|maleate|tartrate|mesylate|besylate|camsylate|gluconate|bitartrate|edisylate|propionate|calcium|magnesium|fumarate|hydrochloride)\b/gi;
 
   const importantSaltPairs = [
     ['diclofenac sodium',      'diclofenac potassium'],

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -245,10 +245,26 @@ describe('Medication comparison', () => {
     expect(result).toBe('Unchanged');
   });
 
-  test('Fluticasone propionate omission flags formulation', () => {
+  test('Fluticasone propionate omission flags quantity only', () => {
     const ctx = loadAppContext();
     const before = ctx.parseOrder('Fluticasone Propionate Nasal Spray 50 mcg/spray - 2 sprays in each nostril once daily');
     const after = ctx.parseOrder('Fluticasone Nasal Spray 50mcg - Use 1 spray per nostril qd');
+    const result = ctx.getChangeReason(before, after);
+    expect(result).toBe('Quantity changed');
+  });
+
+  test('Trivial propionate difference ignored', () => {
+    const ctx = loadAppContext();
+    const before = ctx.parseOrder('Drugname Propionate 10mg tablet');
+    const after = ctx.parseOrder('Drugname 10mg tablet');
+    const result = ctx.getChangeReason(before, after);
+    expect(result).toBe('Unchanged');
+  });
+
+  test('ER formulation difference still flagged', () => {
+    const ctx = loadAppContext();
+    const before = ctx.parseOrder('Drugname Propionate 10mg ER tablet');
+    const after = ctx.parseOrder('Drugname Propionate 10mg tablet');
     const result = ctx.getChangeReason(before, after);
     expect(result).toMatch(/Formulation changed/);
   });

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -139,19 +139,19 @@ addTest('Vitamin D brand/generic without formulation change', () => {
 addTest('Fluticasone spray dose total', () => {
   const before = 'Fluticasone Propionate Nasal Spray 50 mcg/spray - 2 sprays in each nostril once daily';
   const after = 'Fluticasone Nasal Spray 50mcg - Use 1 spray per nostril qd';
-  expect(diff(before, after)).toBe('Formulation changed, Quantity changed');
+  expect(diff(before, after)).toBe('Quantity changed');
 });
 
 addTest('Fluticasone quantity change', () => {
   const before = 'Fluticasone Propionate Nasal Spray 50 mcg/spray – 2 sprays in each nostril daily';
   const after = 'Fluticasone Nasal Spray 50 mcg – 1 spray per nostril qd';
-  expect(diff(before, after)).toBe('Formulation changed, Quantity changed');
+  expect(diff(before, after)).toBe('Quantity changed');
 });
 
 addTest('Fluticasone formulation flagged', () => {
   const before = 'Fluticasone Propionate Nasal Spray 50 mcg/spray – 2 sprays each nostril daily';
   const after = 'Fluticasone Nasal Spray 50 mcg – 1 spray per nostril qd';
-  expect(diff(before, after)).toBe('Formulation changed, Quantity changed');
+  expect(diff(before, after)).toBe('Quantity changed');
 });
 
 addTest('Warfarin sodium formulation difference', () => {
@@ -257,7 +257,7 @@ addTest('Metformin ER vs IR keeps formulation flag only', () => {
 addTest('Fluticasone propionate omission not formulation', () => {
   const before = 'Fluticasone Propionate nasal spray 50 mcg – 2 sprays each nostril daily';
   const after  = 'Fluticasone nasal spray 50 mcg – 1 spray each nostril qd';
-  expect(diff(before, after)).toBe('Formulation changed, Quantity changed');
+  expect(diff(before, after)).toBe('Quantity changed');
 });
 
 addTest('Anxious vs anxiety = no indication flag', () => {


### PR DESCRIPTION
## Summary
- treat propionate as a trivial salt
- update fluticasone test expectations
- add tests for trivial propionate differences
- show ER formulation still flagged

## Testing
- `npm test`