### PR TITLE
Fix brand detection for generics and update tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -1673,6 +1673,7 @@ function hasContra(orderObj, wholeList = []) {
       { generic: "ketorolac", brands: ["Toradol"] },
       { generic: "levothyroxine", brands: ["Synthroid", "Levoxyl"] },
       { generic: "lisinopril", brands: ["Prinivil", "Zestril"] },
+      { generic: "lisinopril-hydrochlorothiazide", brands: ["Zestoretic"] },
       { generic: "lorazepam", brands: ["Ativan"] },
       { generic: "losartan", brands: ["Cozaar"] },
       { generic: "melatonin", brands: [] },
@@ -2566,7 +2567,7 @@ function inhaled(parsedOrder) {
     return false;
 }
 
-const benignBrandSet = new Set(['k-dur']);
+const benignBrandSet = new Set(['k-dur', 'hctz']);
 
 const coreName = n => (n||'')
   .toLowerCase()
@@ -2619,16 +2620,23 @@ function getChangeReason(orig, updated) {
   const base1 = stripStrength(orig.drug);
   const base2 = stripStrength(updated.drug);
 
-  const leftHasBrand  = (orig.brandTokens || []).length > 0;
-  const rightHasBrand = (updated.brandTokens || []).length > 0;
+  const leftHasBrand =
+    (orig.brandTokens || []).some(t => !benignBrandSet.has(t.toLowerCase())) ||
+    Boolean(brandToGenericMap[coreName(base1)]);
+  const rightHasBrand =
+    (updated.brandTokens || []).some(t => !benignBrandSet.has(t.toLowerCase())) ||
+    Boolean(brandToGenericMap[coreName(base2)]);
 
 
   const generic1 = brandToGenericMap[base1] || coreDrugName(base1);
   const generic2 = brandToGenericMap[base2] || coreDrugName(base2);
 
-  if (generic1 === generic2 &&
-      base1 !== base2 &&
-      !changes.includes('Brand/Generic changed')) {
+  if (
+    generic1 === generic2 &&
+    base1 !== base2 &&
+    (leftHasBrand || rightHasBrand) &&
+    !changes.includes('Brand/Generic changed')
+  ) {
     changes.push('Brand/Generic changed');
   }
 
@@ -2637,6 +2645,7 @@ function getChangeReason(orig, updated) {
   if (
     sameDrugCore(orig.drug, updated.drug) &&
     gen1 !== gen2 &&
+    (leftHasBrand || rightHasBrand) &&
     !changes.includes('Brand/Generic changed')
   ) {
     changes.push('Brand/Generic changed');
@@ -2984,6 +2993,9 @@ function getChangeReason(orig, updated) {
     );
     if (!formulationMatch && saltSwap && !changes.includes('Formulation changed')) {
       changes.push('Formulation changed');
+    }
+    if (!leftHasBrand && !rightHasBrand) {
+      changes = changes.filter(c => c !== 'Brand/Generic changed');
     }
   }
 

--- a/tests/changeReason.test.js
+++ b/tests/changeReason.test.js
@@ -30,7 +30,7 @@ describe('getChangeReason', () => {
       route: ''
     };
     const result = ctx.getChangeReason(before, after);
-    expect(result).toBe('Frequency changed, Brand/Generic changed');
+    expect(result).toBe('Frequency changed');
   });
 
   test('Inhaler brand swap not flagged as frequency change', () => {

--- a/tests/getChangeReason.test.js
+++ b/tests/getChangeReason.test.js
@@ -26,4 +26,36 @@ describe('getChangeReason', () => {
     expect(r).toMatch(/Frequency changed/);
     expect(r).toMatch(/Time of day changed/);
   });
+
+  test('Lisinopril/HCTZ wording difference is Unchanged', () => {
+    const ctx = loadAppContext();
+    const o = ctx.parseOrder('Lisinopril/HCTZ 20-12.5mg - 1 tab daily');
+    const u = ctx.parseOrder('Lisinopril 20mg / Hydrochlorothiazide 12.5mg combination tablet - 1 tablet PO daily');
+    const r = ctx.getChangeReason(o, u);
+    expect(r).toBe('Unchanged');
+  });
+
+  test('Brand to generic triggers Brand/Generic changed', () => {
+    const ctx = loadAppContext();
+    const o = ctx.parseOrder('Zestoretic 20-12.5mg - 1 tab daily');
+    const u = ctx.parseOrder('Lisinopril/HCTZ 20-12.5mg - 1 tab daily');
+    const r = ctx.getChangeReason(o, u);
+    expect(r).toMatch(/Brand\/Generic changed/);
+  });
+
+  test('Generic to brand triggers Brand/Generic changed', () => {
+    const ctx = loadAppContext();
+    const o = ctx.parseOrder('Lisinopril/HCTZ 20-12.5mg - 1 tab daily');
+    const u = ctx.parseOrder('Zestoretic 20-12.5mg - 1 tab daily');
+    const r = ctx.getChangeReason(o, u);
+    expect(r).toMatch(/Brand\/Generic changed/);
+  });
+
+  test('Amlodipine vs besylate not flagged as change', () => {
+    const ctx = loadAppContext();
+    const o = ctx.parseOrder('Amlodipine tablet 5mg - 1 PO daily');
+    const u = ctx.parseOrder('Amlodipine besylate tablet 5mg - 1 PO daily');
+    const r = ctx.getChangeReason(o, u);
+    expect(r).toBe('Unchanged');
+  });
 });

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -215,7 +215,7 @@ addTest('Spiriva brand/generic flag', () => {
 addTest('HCTZ abbreviation no brand flag', () => {
   const before = 'Lisinopril/HCTZ 20-12.5mg PO daily';
   const after  = 'Lisinopril 20mg / Hydrochlorothiazide 12.5mg PO daily';
-  expect(diff(before, after)).toBe('Brand/Generic changed');
+  expect(diff(before, after)).toBe('');
 });
 
 addTest('Insulin TIDAC equals before meals (no freq flag)', () => {
@@ -917,7 +917,7 @@ addTest('benign brand swaps', () => {
   expect(diff('ProAir 90 mcg 2 puffs PRN', 'Albuterol HFA 90 mcg 2 puffs PRN'))
     .toBe('Brand/Generic changed');
   expect(diff('K-Dur 10 mEq ER tab BID', 'Potassium Chloride 10 mEq ER tab BID'))
-    .toBe('Brand/Generic changed');
+    .toBe('');
   expect(diff('Lasix 20 mg qAM', 'Furosemide 20 mg daily')).toBe(
     'Brand/Generic changed, Time of day changed'
   );


### PR DESCRIPTION
## Summary
- handle benign brand tokens when checking for Brand/Generic changes
- ignore brand/generic flag when normalized drugs match and no real brand is involved
- add Zestoretic mapping
- expand unit tests for Lisinopril/HCTZ wording and brand cases
- update expectations for previous tests

## Testing
- `npm test`