### PR TITLE
Improve keepOrderLines logging and regex

### DIFF
--- a/index.html
+++ b/index.html
@@ -680,7 +680,7 @@ footer a:hover {
       'naltrexone', 'naloxone', 'flumazenil', 'desmopressin', 'octreotide', 'erythropoietin', 'filgrastim',
       'calcitriol', 'ergocalciferol', 'cholecalciferol', 'pyridostigmine', 'propranolol', 'labetalol',
       'isosorbide', 'nicardipine', 'nitroprusside', 'ivabradine', 'sacubitril', 'valsartan',
-      'atorvastatin', 'rosuvastatin', 'simvastatin', 'Norco', 'oxycodone/acetaminophen', 'hydrocodone/acetaminophen', 'codeine/acetaminophen', 'tramadol/acetaminophen', 'acetaminophen/caffeine/dihydrocodeine', 'aspirin/caffeine/dihydrocodeine', 'aspirin/codeine', 'ibuprofen/oxycodone', 'acetaminophen/butalbital/caffeine', 'aspirin/butalbital/caffeine', 'acetaminophen/butalbital', 'methylphenidate', 'amphetamine/dextroamphetamine', 'hydrocodone/pseudoephedrine', 'hydrocodone/chlorpheniramine', 'hydrocodone/homatropine', 'busulfan', 'doxorubicin', 'adalimumab', 'acetaminophen/isometheptene/dichloralphenazone', 'ultracet', 'percocet', 'roxicet', 'endocet', 'tylenol #3', 'zamicet', 'vicodin', 'lortab', 'panlor ss', 'trezix', 'synalgos-dc', 'empirin with codeine', 'combunox', 'fioricet', 'esgic', 'zebutal', 'fiorinal', 'bupap', 'rezira', 'tussionex', 'hycomine', 'hydromet', 'midrin','chlorpropamide', 'acarbose', 'miglitol', 'argatroban', 'bivalirudin', 'fondaparinux', 'methylergonovine', 'carboplatin', 'cyclophosphamide', 'promethazine'
+      'atorvastatin', 'rosuvastatin', 'simvastatin', 'Norco', 'oxycodone/acetaminophen', 'hydrocodone/acetaminophen', 'codeine/acetaminophen', 'tramadol/acetaminophen', 'acetaminophen/caffeine/dihydrocodeine', 'aspirin/caffeine/dihydrocodeine', 'aspirin/codeine', 'ibuprofen/oxycodone', 'acetaminophen/butalbital/caffeine', 'aspirin/butalbital/caffeine', 'acetaminophen/butalbital', 'methylphenidate', 'amphetamine/dextroamphetamine', 'hydrocodone/pseudoephedrine', 'hydrocodone/chlorpheniramine', 'hydrocodone/homatropine', 'busulfan', 'doxorubicin', 'adalimumab', 'acetaminophen/isometheptene/dichloralphenazone', 'ultracet', 'percocet', 'roxicet', 'endocet', 'tylenol #3', 'zamicet', 'vicodin', 'lortab', 'panlor ss', 'trezix', 'synalgos-dc', 'empirin with codeine', 'combunox', 'fioricet', 'esgic', 'zebutal', 'fiorinal', 'bupap', 'rezira', 'tussionex', 'hycomine', 'hydromet', 'midrin','chlorpropamide', 'acarbose', 'miglitol', 'argatroban', 'bivalirudin', 'fondaparinux', 'methylergonovine', 'carboplatin', 'cyclophosphamide', 'promethazine', 'timolol'
 
     ].map(med => med.toLowerCase());
 
@@ -2166,12 +2166,21 @@ function keepOrderLines(rawText) {
 
   // 5. Final filter for valid-looking order lines
   const finalFilteredLines = processedLines.filter(line => {
-    const keep =
-      line.trim() && // Ensure line is not just whitespace after all processing
-      isLikelyOrderLine(line) &&
-      (containsKnownMedication(line) ||
-        /\d+\s*(mg|mcg|g|mL|units|tablet|capsule|puff|drop)\b/i.test(line)) &&
-      /\d/.test(line);
+    const likely = isLikelyOrderLine(line);
+    const known = containsKnownMedication(line);
+    const unitMatch = /\d+\s*(mg|mcg|g|mL|mEq|IU|units|tablet|capsule|puff|drop|gtt|gtts)\b/i.test(line);
+    const hasDigit = /\d/.test(line);
+    const keep = line.trim() && likely && (known || unitMatch) && hasDigit;
+
+    if (/timolol/i.test(line)) {
+      console.log('DEBUG keepOrderLines Timolol line:', line);
+      console.log('  isLikelyOrderLine:', likely);
+      console.log('  containsKnownMedication:', known);
+      if (!known) console.log('  dose+unit regex match:', unitMatch);
+      console.log('  contains digit:', hasDigit);
+      console.log('  keep decision:', keep);
+    }
+
     if (!keep && DEBUG_JUNK && line.trim()) console.log('🗑️ Final filter dropping line:', line);
     return keep;
   });

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -206,3 +206,14 @@ describe('parseQuantity', () => {
     expect(ctx.parseQuantity('\u00bd tab')).toBe(0.5);
   });
 });
+
+describe('keepOrderLines + parseOrder', () => {
+  test('Timolol ophthalmic order retained and parsed', () => {
+    const ctx = loadAppContext();
+    const raw = 'Timolol 0.5% ophthalmic solution - instill 1 gtt OU BID for glaucoma';
+    const lines = ctx.keepOrderLines(raw);
+    expect(lines.length).toBe(1);
+    const order = ctx.parseOrder(lines[0]);
+    expect(order.drug.toLowerCase()).toMatch(/timolol/);
+  });
+});


### PR DESCRIPTION
## Summary
- add detailed diagnostic logs for Timolol lines in `keepOrderLines`
- expand fallback unit regex and include gtt/gtts
- ensure Timolol recognized as critical medication
- test that Timolol ophthalmic order is retained and parsed

## Testing
- `npm test`