### PR TITLE
Update parseOrder scoring logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -4709,35 +4709,35 @@ if (!order.drug && initialCleanedDrugString &&
 applyFinalNormalizations(order, troughNote, originalRaw);
   // calculate parsing confidence
   if (!order.drug || /^(medication|tablet)$/i.test(order.drug)) {
-    parsingConfidence -= 35;
+    parsingConfidence -= 40;
   }
   if (order.dose.value === null) {
-    parsingConfidence -= 30;
+    parsingConfidence -= 35;
   }
   if (order.dose.value !== null && !order.dose.unit) {
-    parsingConfidence -= 15;
+    parsingConfidence -= 20;
   }
   if (!order.frequency && !order.prn) {
-    parsingConfidence -= 15;
+    parsingConfidence -= 20;
   }
   if (!order.route) {
-    parsingConfidence -= 10;
+    parsingConfidence -= 15;
   }
 
   const origLen = (originalRaw || '').replace(/\s+/g, '').length || 1;
   const leftoverLen = (orderStr || '').replace(/\s+/g, '').length;
   const ratio = leftoverLen / origLen;
-  if (ratio > 0.3) {
-    parsingConfidence -= 25;
-  } else if (ratio > 0.15) {
+  if (ratio > 0.25) {
+    parsingConfidence -= 30;
+  } else if (ratio > 0.1) {
     parsingConfidence -= 15;
   }
 
   if (ocrConfidenceValue !== undefined && ocrConfidenceValue !== null) {
     if (ocrConfidenceValue < 0.6) {
-      parsingConfidence -= 20;
+      parsingConfidence -= 25;
     } else if (ocrConfidenceValue < 0.8) {
-      parsingConfidence -= 10;
+      parsingConfidence -= 15;
     }
   }
 


### PR DESCRIPTION
## Summary
- adjust parseOrder confidence deductions for missing fields
- update ratio and OCR penalties

## Testing
- `npm test`
- `npm run lint`
