### PR TITLE
Improve indication normalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -2250,11 +2250,13 @@ function normalizeText(str) {
 function normalizeIndicationText(txt = '') {
   let s = txt.toLowerCase()
              .replace(/[.;,]+/g, ' ')
-               .replace(/\bstart\s*date.*$/g,'')
-              .replace(/\b(?:start|date)\b/g,'')
-              .replace(/\b(?:spray|inject|inhale|use|apply|puff|inhalations?|contents|device|handihaler|respimat|flexpen|each|per|in|via|of|one|two)\b/gi,'')
-             .replace(/\s+/g,' ')
-             .trim();
+              .replace(/\bstart\s*date.*$/g,'')
+             .replace(/\b(?:start|date)\b/g,'')
+             .replace(/\b(?:spray|inject|inhale|use|apply|puff|inhalations?|contents|device|handihaler|respimat|flexpen|each|per|in|via|of|one|two)\b/gi,'')
+            .replace(/\s+/g,' ')
+            .trim();
+
+  s = s.replace(/\b(?:pain relief strategy|pain management(?: plan| strategy)?|pain control(?: strategy)?|pain plan)\b.*$/,'').trim();
 
   const synonyms = {
     'afib': 'atrial fibrillation',
@@ -2307,6 +2309,10 @@ function normalizeIndication(txt) {
   txt = txt
     .replace(fillerRE, ' ')
     .replace(/\s+/g, ' ')
+    .trim();
+
+  txt = txt
+    .replace(/\b(?:pain relief strategy|pain management(?: plan| strategy)?|pain control(?: strategy)?|pain plan)\b.*$/, '')
     .trim();
   const synonyms = {
     'shortness of breath': 'breathing difficulty',

--- a/tests/medDiff.test.js
+++ b/tests/medDiff.test.js
@@ -139,6 +139,16 @@ describe('Medication comparison', () => {
     expect(order.indication).toBe('neuropathy');
   });
 
+  test('nerve pain vs neuropathy pain relief strategy normalized equal', () => {
+    const ctx = loadAppContext();
+    const before = ctx.parseOrder('Gabapentin 300 mg capsule - take 1 cap tid for nerve pain');
+    const after = ctx.parseOrder('Gabapentin 300 mg capsule - take 1 cap tid for neuropathy pain relief strategy');
+    expect(before.indication).toBe('neuropathy');
+    expect(after.indication).toBe('neuropathy');
+    const result = ctx.getChangeReason(before, after);
+    expect(result).toBe('Unchanged');
+  });
+
   test('administration difference flagged', () => {
     const ctx = loadAppContext();
     const before = 'Metformin 500 mg tablet - take 1 tablet with food daily';


### PR DESCRIPTION
## Summary
- extend `normalizeIndicationText` and `normalizeIndication` to strip trailing pain‑management phrases
- add regression test showing "nerve pain" equals "neuropathy pain relief strategy"

## Testing
- `npm test`