### PR TITLE
Improve confidence scoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -4730,13 +4730,15 @@ applyFinalNormalizations(order, troughNote, originalRaw);
     parsingConfidence -= 15;
   }
 
+  const ANCILLARY_REGEX = /\b(?:continue\s+(?:home\s+)?dose|with\s+(?:food|meals?|supper|dinner|breakfast|lunch)|pharmacy\s+to\s+clarify)\b/gi;
   const origLen = (originalRaw || '').replace(/\s+/g, '').length || 1;
-  const leftoverLen = (orderStr || '').replace(/\s+/g, '').length;
+  let penaltyStr = (orderStr || '').replace(ANCILLARY_REGEX, '').trim();
+  const leftoverLen = penaltyStr.replace(/\s+/g, '').length;
   const ratio = leftoverLen / origLen;
-  if (ratio > 0.3) {
-    parsingConfidence -= 25;
-  } else if (ratio > 0.15) {
-    parsingConfidence -= 10;
+  if (ratio > 0.4) {
+    parsingConfidence -= 20;
+  } else if (ratio > 0.2) {
+    parsingConfidence -= 5;
   }
 
   if (ocrConfidenceValue !== undefined && ocrConfidenceValue !== null) {
@@ -5553,7 +5555,10 @@ const finalResults = [];
 
 // ‑‑‑ FIRST: show the neatly‑merged pairs ‑‑‑
 merged.forEach(pair => {
-  const rowConfidence = Math.min(pair.orig.confidence, pair.new.confidence);
+  let rowConfidence = Math.min(pair.orig.confidence, pair.new.confidence);
+  if (pair.reason === 'Unchanged') {
+    rowConfidence = Math.max(95, (pair.orig.confidence + pair.new.confidence) / 2);
+  }
   finalResults.push({
     orig: pair.orig,
     new: pair.new,
@@ -5625,7 +5630,13 @@ if (!match) {
               ci: ciSet.has(coreDrugName(r.parsed.drug)) ||
                   (match && ciSet.has(coreDrugName(match.parsed.drug))),
               changes: reasons,
-              rowConfidence: Math.min(r.confidence, match.confidence)
+              rowConfidence: (() => {
+                let rc = Math.min(r.confidence, match.confidence);
+                if (reasons.length === 1 && reasons[0] === 'Unchanged') {
+                  rc = Math.max(95, (r.confidence + match.confidence) / 2);
+                }
+                return rc;
+              })()
             });
      added = added.filter(a => a !== match);
      if (DEBUG) console.groupEnd();
@@ -5643,7 +5654,13 @@ if (!match) {
                 critical: crit,
                 ci: false,
                 changes: reason === 'Unchanged' ? [] : [reason],
-                rowConfidence: Math.min(r.confidence, match.confidence)
+                rowConfidence: (() => {
+                    let rc = Math.min(r.confidence, match.confidence);
+                    if (reason === 'Unchanged') {
+                      rc = Math.max(95, (r.confidence + match.confidence) / 2);
+                    }
+                    return rc;
+                })()
             });
             added = added.filter(a => a !== match);
             if (DEBUG) console.groupEnd();
@@ -5663,7 +5680,13 @@ if (!match) {
                 critical: crit,
                 ci: false,
                 changes: reason === 'Unchanged' ? [] : [reason],
-                rowConfidence: Math.min(r.confidence, sameDrug.confidence)
+                rowConfidence: (() => {
+                    let rc = Math.min(r.confidence, sameDrug.confidence);
+                    if (reason === 'Unchanged') {
+                      rc = Math.max(95, (r.confidence + sameDrug.confidence) / 2);
+                    }
+                    return rc;
+                })()
             });
             added = added.filter(a => a !== sameDrug);
             if (DEBUG) console.groupEnd();
@@ -5696,7 +5719,13 @@ if (!match) {
         ci: ciSet.has(coreDrugName(u.orig.parsed.drug)) ||
             ciSet.has(coreDrugName(u.new.parsed.drug)),
         changes: label === 'Unchanged' ? [] : [label],
-        rowConfidence: Math.min(u.orig.confidence, u.new.confidence)
+        rowConfidence: (() => {
+          let rc = Math.min(u.orig.confidence, u.new.confidence);
+          if (label === 'Unchanged') {
+            rc = Math.max(95, (u.orig.confidence + u.new.confidence) / 2);
+          }
+          return rc;
+        })()
       });
      });
 

--- a/tests/confidence.test.js
+++ b/tests/confidence.test.js
@@ -76,4 +76,28 @@ describe('parsing confidence', () => {
       )
     ).toBe(true);
   });
+
+  test('Pantoprazole added order high confidence', () => {
+    const ctx = loadAppContext();
+    const res = ctx.parseOrderFull('Pantoprazole 40mg DR tab - 1 po daily for GERD');
+    expect(res.confidence >= 85).toBe(true);
+  });
+
+  test('Clonidine patch added order high confidence', () => {
+    const ctx = loadAppContext();
+    const res = ctx.parseOrderFull('Clonidine 0.1mg patch - Apply 1 patch topically every 7 days for BP');
+    expect(res.confidence >= 85).toBe(true);
+  });
+
+  test('Unchanged orders yield high row confidence', () => {
+    const ctx = loadAppContext();
+    const orig = ctx.parseOrderFull('Metformin hydrochloride 1000mg ER tablet - Take one tablet by mouth every evening with supper');
+    const upd = ctx.parseOrderFull('Metformin ER 1000mg - Take 1 tab po nightly with food continue home dose');
+    const reason = ctx.getChangeReason(orig.parsed, upd.parsed);
+    let rowConf = Math.min(orig.confidence, upd.confidence);
+    if (reason === 'Unchanged') {
+      rowConf = Math.max(95, (orig.confidence + upd.confidence) / 2);
+    }
+    expect(rowConf >= 85).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- relax unparsed text penalties for minor ancillary phrases
- boost row confidence for unchanged orders
- add test cases for confidence rules

## Testing
- `npm test`