### PR TITLE
Centralize frequency and time of day maps

### DIFF
--- a/index.html
+++ b/index.html
@@ -651,6 +651,7 @@ footer a:hover {
     }
   </script>
 
+  <script src="src/frequencyMaps.js"></script>
   <script>
     const DEBUG = false;
     const criticalMeds = [
@@ -2353,36 +2354,9 @@ function normalizeIndication(txt) {
 
 function normalizeTimeOfDay(t) {
   if (!t) return '';
-    const aliases = {
-      morning: 'morning',
-      qam: 'morning',
-      am: 'morning',
-      'every am': 'morning',
-      'every morning': 'morning',
-      'in morning': 'morning',
-      'in the morning': 'morning',
-      'daily in morning': 'morning',
-      evening: 'bedtime',
-      evenings: 'bedtime',
-      pm: 'bedtime',
-      qpm: 'bedtime',
-      'every evening': 'bedtime',
-      'daily in evening': 'bedtime',
-      'in evening': 'bedtime',
-      'in the evening': 'bedtime',
-      'in the evenings': 'bedtime',
-      'in the pm': 'bedtime',
-      bedtime: 'bedtime',
-      night: 'bedtime',
-      qhs: 'bedtime',
-      nightly: 'bedtime',
-      'at bedtime': 'bedtime',
-      'at night': 'bedtime',
-      'every night': 'bedtime',
-      noon: 'noon',
-      midday: 'noon',
-      'at noon': 'noon'
-    };
+  const aliases = typeof TIME_OF_DAY_ALIASES !== 'undefined'
+    ? TIME_OF_DAY_ALIASES
+    : {};
   t = t.toLowerCase().trim();
   if (aliases[t]) return aliases[t];
   for (const key in aliases) {
@@ -2413,54 +2387,7 @@ function sameIndication(a, b) {
 }
 
 function getFrequencyMap() {
-  return {
-    'once daily': 'daily',
-    'once a day': 'daily',
-    '1 times daily': 'daily',
-    daily: 'daily',
-    od: 'daily',
-    qd: 'daily',
-    'every morning': 'daily',
-    'daily in morning': 'daily',
-    'daily in the morning': 'daily',
-    'daily in evening': 'daily',
-    'daily in the evening': 'daily',
-    'daily at noon': 'daily',
-    'daily in noon': 'daily',
-    'twice daily': 'bid',
-    '2 times daily': 'bid',
-    '2 times a day': 'bid',
-    'two times daily': 'bid',
-    'two times a day': 'bid',      // NEW alias → BID
-    'twice a day': 'bid',
-    bid: 'bid',
-    'twice a day with meals': 'bid',
-    'twice daily with meals': 'bid',
-    'three times daily': 'tid',
-    'three times a day': 'tid',
-    '3 times daily': 'tid',
-    tid: 'tid',
-    tidac: 'tid',
-    'before meals': 'tid',
-    'with meals': 'tid',
-    'before breakfast lunch dinner': 'tid',
-    'four times daily': 'qid',
-    'four times a day': 'qid',
-    '4 times daily': 'qid',
-    qid: 'qid',
-    'every other day': 'every other day',
-    qod: 'every other day',
-    'every 4-6 hours': 'q4-6h',
-    'every 4 to 6 hours': 'q4-6h',
-    stat: 'immediately',
-    now: 'immediately',
-    immediately: 'immediately',
-    weekly: 'weekly',
-    'once a week': 'weekly',
-    'once per week': 'weekly',
-    monthly: 'monthly',
-    'once a month': 'monthly'
-  };
+  return typeof FREQUENCY_MAP !== 'undefined' ? FREQUENCY_MAP : {};
 }
 
 function normalizeFrequency(str) {

--- a/src/frequencyMaps.js
+++ b/src/frequencyMaps.js
@@ -1,0 +1,88 @@
+(function(global) {
+  const TIME_OF_DAY_ALIASES = {
+    morning: 'morning',
+    qam: 'morning',
+    am: 'morning',
+    'every am': 'morning',
+    'every morning': 'morning',
+    'in morning': 'morning',
+    'in the morning': 'morning',
+    'daily in morning': 'morning',
+    evening: 'bedtime',
+    evenings: 'bedtime',
+    pm: 'bedtime',
+    qpm: 'bedtime',
+    'every evening': 'bedtime',
+    'daily in evening': 'bedtime',
+    'in evening': 'bedtime',
+    'in the evening': 'bedtime',
+    'in the evenings': 'bedtime',
+    'in the pm': 'bedtime',
+    bedtime: 'bedtime',
+    night: 'bedtime',
+    qhs: 'bedtime',
+    nightly: 'bedtime',
+    'at bedtime': 'bedtime',
+    'at night': 'bedtime',
+    'every night': 'bedtime',
+    noon: 'noon',
+    midday: 'noon',
+    'at noon': 'noon'
+  };
+
+  const FREQUENCY_MAP = {
+    'once daily': 'daily',
+    'once a day': 'daily',
+    '1 times daily': 'daily',
+    daily: 'daily',
+    od: 'daily',
+    qd: 'daily',
+    'every morning': 'daily',
+    'daily in morning': 'daily',
+    'daily in the morning': 'daily',
+    'daily in evening': 'daily',
+    'daily in the evening': 'daily',
+    'daily at noon': 'daily',
+    'daily in noon': 'daily',
+    'twice daily': 'bid',
+    '2 times daily': 'bid',
+    '2 times a day': 'bid',
+    'two times daily': 'bid',
+    'two times a day': 'bid',
+    'twice a day': 'bid',
+    bid: 'bid',
+    'twice a day with meals': 'bid',
+    'twice daily with meals': 'bid',
+    'three times daily': 'tid',
+    'three times a day': 'tid',
+    '3 times daily': 'tid',
+    tid: 'tid',
+    tidac: 'tid',
+    'before meals': 'tid',
+    'with meals': 'tid',
+    'before breakfast lunch dinner': 'tid',
+    'four times daily': 'qid',
+    'four times a day': 'qid',
+    '4 times daily': 'qid',
+    qid: 'qid',
+    'every other day': 'every other day',
+    qod: 'every other day',
+    'every 4-6 hours': 'q4-6h',
+    'every 4 to 6 hours': 'q4-6h',
+    stat: 'immediately',
+    now: 'immediately',
+    immediately: 'immediately',
+    weekly: 'weekly',
+    'once a week': 'weekly',
+    'once per week': 'weekly',
+    monthly: 'monthly',
+    'once a month': 'monthly'
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { TIME_OF_DAY_ALIASES, FREQUENCY_MAP };
+  } else {
+    global.TIME_OF_DAY_ALIASES = TIME_OF_DAY_ALIASES;
+    global.FREQUENCY_MAP = FREQUENCY_MAP;
+  }
+})(this);

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -86,6 +86,10 @@ function loadAppContext() {
   const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
   const parts = html.split('<script>');
   const script = parts[parts.length - 1].split('</script>')[0];
+  const maps = fs.readFileSync(
+    path.join(__dirname, '..', 'src', 'frequencyMaps.js'),
+    'utf8'
+  );
   const helpers = fs.readFileSync(
     path.join(__dirname, '..', 'src', 'orderParsingHelpers.js'),
     'utf8'
@@ -97,6 +101,7 @@ function loadAppContext() {
     firebase: { initializeApp: () => ({}), functions: () => ({ httpsCallable: () => () => ({}) }) }
   };
   vm.createContext(context);
+  vm.runInContext(maps, context);
   vm.runInContext(helpers, context);
   vm.runInContext(script, context);
   const origParse = context.parseOrder;


### PR DESCRIPTION
## Summary
- expose time of day and frequency synonyms in new `src/frequencyMaps.js`
- include the new script in `index.html`
- update `normalizeTimeOfDay` and `getFrequencyMap` to use the shared data
- load `frequencyMaps.js` when running the test harness

## Testing
- `npm run lint`
- `npm test`
