### PR TITLE
Fix disappearing header divider

### DIFF
--- a/index.html
+++ b/index.html
@@ -5933,6 +5933,8 @@ function printResults() {
     document.addEventListener('DOMContentLoaded', () => {
       hideLoading();
       updateProgress('disclaimer-screen');
+      const divider = document.querySelector('.header-divider');
+      if (divider) divider.style.display = 'block';
     });
   </script>
 


### PR DESCRIPTION
## Summary
- ensure the divider in the header stays visible after page load

## Testing
- `npm test`
- `npm run lint`
