### PR TITLE
Ignore discontinued orders in parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -2215,6 +2215,12 @@ function pruneLine(line) {
  }
 
     function isLikelyOrderLine(line) {
+      const discontinuationPattern = /\b(discontinued|d\s*\/?\s*c(?:(?:[\s.-]*ed|[\s.-]*'d))?|discont\.?)\b/i;
+      if (discontinuationPattern.test(line)) {
+        if (DEBUG) console.log('Filtered discontinued line:', line);
+        return false;
+      }
+
       //=== STEP 3  stricter test
 if (line.length < 5) return false;
 const good = (line.match(/[a-z0-9]/gi) || []).length;

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -226,6 +226,36 @@ describe('keepOrderLines + parseOrder', () => {
   });
 });
 
+describe('keepOrderLines discontinued handling', () => {
+  test('lines with discontinued text are excluded', () => {
+    const ctx = loadAppContext();
+    const raw = [
+      'Lisinopril 10 mg tablet daily',
+      'Metformin 500 mg tablet - discontinued',
+      'Amlodipine 5 mg tablet daily'
+    ].join('\n');
+    const lines = ctx.keepOrderLines(raw);
+    expect(lines.length).toBe(2);
+    expect(lines.some(l => /metformin/i.test(l))).toBe(false);
+  });
+
+  test('lines with D/C abbreviation are excluded', () => {
+    const ctx = loadAppContext();
+    const raw = 'Warfarin 5mg D/C\nLisinopril 10mg active';
+    const lines = ctx.keepOrderLines(raw);
+    expect(lines.length).toBe(1);
+    expect(lines.some(l => /warfarin/i.test(l))).toBe(false);
+  });
+
+  test("lines with dc'd abbreviation are excluded", () => {
+    const ctx = loadAppContext();
+    const raw = 'Aspirin 81mg dc\'d\nClopidogrel 75mg';
+    const linesDcEd = ctx.keepOrderLines(raw);
+    expect(linesDcEd.length).toBe(1);
+    expect(linesDcEd.some(l => /aspirin/i.test(l))).toBe(false);
+  });
+});
+
 describe('normalizeMedicationName', () => {
   test('strips dosage form words like caps', () => {
     const ctx = loadAppContext();


### PR DESCRIPTION
## Summary
- filter discontinued orders when keeping order lines
- expand regex coverage to catch more discontinuation phrases
- add tests covering D/C and dc'd abbreviations

## Testing
- `npm run lint`
- `npm test`
